### PR TITLE
Fix character editor camera rotating with UI click

### DIFF
--- a/Assets/Scripts/Cameras/CharacterEditorCamera.cs
+++ b/Assets/Scripts/Cameras/CharacterEditorCamera.cs
@@ -8,6 +8,7 @@ using GameProgress;
 using Map;
 using GameManagers;
 using Events;
+using UnityEngine.EventSystems;
 
 namespace Cameras
 {
@@ -26,6 +27,10 @@ namespace Cameras
 
         protected void Update()
         {
+            if(EventSystem.current.IsPointerOverGameObject()) {
+                return;
+            }
+
             float mouseX = Input.mousePosition.x;
             if (UIManager.CurrentMenu == null || UIManager.CurrentMenu.GetComponent<CharacterEditorMenu>() == null)
                 return;


### PR DESCRIPTION
- Added a check in the camera control script to detect if the current pointer is over a UI GameObject. If the pointer is over any UI element, the camera movement is disabled. This ensures that interacting with UI elements like sliders or buttons does not inadvertently affect the camera's position or rotation.

![CleanShot 2023-11-27 at 22 55 31](https://github.com/AoTTG-2/Aottg2-Unity/assets/78424395/941774c4-eefd-4eba-8741-7aad39205582)
