### PR TITLE
Supply skill cooldown

### DIFF
--- a/Assets/Scripts/Characters/BaseUseable/BaseUseable.cs
+++ b/Assets/Scripts/Characters/BaseUseable/BaseUseable.cs
@@ -44,7 +44,7 @@ namespace Characters
 
         public float GetCooldownRatio()
         {
-            if (!HasUsesLeft()/* && Cooldown == 0*/)
+            if (!HasUsesLeft())
                 return 0f;
             if (Cooldown == 0f)
                 return 1f;

--- a/Assets/Scripts/Characters/Human/Human.cs
+++ b/Assets/Scripts/Characters/Human/Human.cs
@@ -485,6 +485,7 @@ namespace Characters
             if (!Grounded || State != HumanState.Idle)
                 return false;
             State = HumanState.Refill;
+            Special.Reset();
             ToggleSparks(false);
             CrossFade(HumanAnimations.Refill, 0.1f);
             PlaySound(HumanSounds.Refill);
@@ -496,6 +497,10 @@ namespace Characters
         {
             if (CurrentGas < MaxGas)
                 return true;
+            if (Special is SupplySpecial && Special.UsesLeft == 0)
+            {
+                return true;
+            }
             if (Weapon is BladeWeapon)
             {
                 var weapon = (BladeWeapon)Weapon;

--- a/Assets/Scripts/Characters/Human/Specials/SupplySpecial.cs
+++ b/Assets/Scripts/Characters/Human/Specials/SupplySpecial.cs
@@ -13,6 +13,7 @@ namespace Characters
         public SupplySpecial(BaseCharacter owner): base(owner)
         {
             UsesLeft = MaxUses = 1;
+            Cooldown = 300;
         }
 
         protected override void Activate()
@@ -25,6 +26,12 @@ namespace Characters
             var rotation = _human.Cache.Transform.rotation.eulerAngles;
             SpawnableSpawner.Spawn(SpawnablePrefabs.Supply, _human.Cache.Transform.position + _human.Cache.Transform.forward * 2f + Vector3.up * 0.5f, 
                 Quaternion.Euler(0f, rotation.y, 90f));
+        }
+
+        public override void Reset()
+        {
+            base.Reset();
+            SetCooldownLeft(Cooldown);
         }
     }
 }


### PR DESCRIPTION
Makes the Supply skill from Once per life to Once per 5 minutes per resupply.

Current implementation starts the Cooldown when you Resupply so until you resupply the ability won't go on cooldown and just be unusable.