### PR TITLE
Fix: Clicking a Radial Menu Item causes AHSS/APG to attack

### DIFF
--- a/Assets/Scripts/UI/InGameMenu/EmoteHandler.cs
+++ b/Assets/Scripts/UI/InGameMenu/EmoteHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Collections;
 using UnityEngine;
 using UnityEngine.Events;
 using UnityEngine.UI;
@@ -167,6 +168,12 @@ namespace UI
                     }
                 }
             }
+            //Wait for long press weapon input check before closing the menu.
+            StartCoroutine(DelayCoroutine());
+        }
+        private IEnumerator DelayCoroutine()
+        {
+            yield return new WaitForSeconds(0.1f);
             _emoteWheelPopup.Hide();
             IsActive = false;
         }
@@ -235,7 +242,7 @@ namespace UI
             bool inMenu = InGameMenu.InMenu() || ((InGameManager)SceneLoader.CurrentGameManager).State == GameState.Loading;
             foreach (var popup in _emoteTextPopups)
                 UpdatePopup(popup, inMenu);
-            foreach(var popup in _emoteEmojiPopups)
+            foreach (var popup in _emoteEmojiPopups)
                 UpdatePopup(popup, inMenu);
         }
     }


### PR DESCRIPTION
Fixed a bug that caused ASSH and RPG to attack when clicking on a radial menu option.

Specifically, after clicking on a menu option, I added a delay to wait for the attack input check before closing the menu.