### PR TITLE
CL QoL Improvements

### DIFF
--- a/Assets/Scripts/CustomLogic/Builtin/CustomLogicColorBuiltin.cs
+++ b/Assets/Scripts/CustomLogic/Builtin/CustomLogicColorBuiltin.cs
@@ -2,6 +2,7 @@
 using Unity.VisualScripting;
 using UnityEngine;
 using Utility;
+using ColorUtility = UnityEngine.ColorUtility;
 
 namespace CustomLogic
 {
@@ -11,10 +12,24 @@ namespace CustomLogic
 
         public CustomLogicColorBuiltin(List<object> parameterValues) : base("Color")
         {
-            if (parameterValues.Count == 0)
-                return;
-            Value = new Color255((int)parameterValues[0], (int)parameterValues[1], 
-                (int)parameterValues[2], (int)parameterValues[3]);
+            var color = new Color255();
+            
+            if (parameterValues.Count == 1)
+            {
+                if (ColorUtility.TryParseHtmlString((string)parameterValues[0], out var c))
+                    color = new Color255(c);
+            }
+            else if (parameterValues.Count == 3)
+            {
+                color = new Color255((int)parameterValues[0], (int)parameterValues[1], (int)parameterValues[2]);
+            }
+            else if (parameterValues.Count == 4)
+            {
+                color = new Color255((int)parameterValues[0], (int)parameterValues[1], 
+                    (int)parameterValues[2], (int)parameterValues[3]);
+            }
+
+            Value = color;
         }
 
         public CustomLogicColorBuiltin(Color255 value) : base("Color")
@@ -83,6 +98,11 @@ namespace CustomLogic
                 return false;
             var other = ((CustomLogicColorBuiltin)obj).Value;
             return Value.R == other.R && Value.G == other.G && Value.B == other.B && Value.A == other.A;
+        }
+
+        public override string ToString()
+        {
+            return $"({Value.R}, {Value.G}, {Value.B}, {Value.A})";
         }
 
         public override CustomLogicStructBuiltin Copy()

--- a/Assets/Scripts/CustomLogic/Builtin/CustomLogicDictBuiltin.cs
+++ b/Assets/Scripts/CustomLogic/Builtin/CustomLogicDictBuiltin.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Text;
 using UnityEngine;
 
 namespace CustomLogic
@@ -69,6 +70,39 @@ namespace CustomLogic
         public override void SetField(string name, object value)
         {
             base.SetField(name, value);
+        }
+
+        public override string ToString()
+        {
+            var builder = new StringBuilder();
+            builder.Append("{");
+
+            var i = 0;
+            foreach (var (key, value) in Dict)
+            {
+                Append(key);
+                builder.Append(": ");
+                Append(value);
+
+                if (i != Dict.Count - 1)
+                    builder.Append(", ");
+                
+                i++;
+            }
+            
+            builder.Append("}");
+            return builder.ToString();
+
+            void Append(object obj)
+            {
+                if (obj is string str)
+                {
+                    builder.Append($"\"{str}\"");
+                    return;
+                }
+
+                builder.Append(obj);
+            }
         }
     }
 }

--- a/Assets/Scripts/CustomLogic/Builtin/CustomLogicListBuiltin.cs
+++ b/Assets/Scripts/CustomLogic/Builtin/CustomLogicListBuiltin.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using UnityEngine;
 
 namespace CustomLogic
@@ -72,6 +73,26 @@ namespace CustomLogic
         public override void SetField(string name, object value)
         {
             base.SetField(name, value);
+        }
+
+        public override string ToString()
+        {
+            var builder = new StringBuilder();
+            builder.Append("[");
+
+            for (var i = 0; i < List.Count; i++)
+            {
+                if (List[i] is string str)
+                    builder.Append($"\"{str}\"");
+                else
+                    builder.Append(List[i]);
+
+                if (i != List.Count - 1)
+                    builder.Append(", ");
+            }
+
+            builder.Append("]");
+            return builder.ToString();
         }
     }
 }

--- a/Assets/Scripts/CustomLogic/Builtin/CustomLogicQuaternionBuiltin.cs
+++ b/Assets/Scripts/CustomLogic/Builtin/CustomLogicQuaternionBuiltin.cs
@@ -102,5 +102,10 @@ namespace CustomLogic
             var other = ((CustomLogicQuaternionBuiltin)obj).Value;
             return Value == other;
         }
+
+        public override string ToString()
+        {
+            return Value.ToString();
+        }
     }
 }

--- a/Assets/Scripts/CustomLogic/Builtin/CustomLogicVector3Builtin.cs
+++ b/Assets/Scripts/CustomLogic/Builtin/CustomLogicVector3Builtin.cs
@@ -10,9 +10,29 @@ namespace CustomLogic
 
         public CustomLogicVector3Builtin(List<object> parameterValues): base("Vector3")
         {
-            if (parameterValues.Count == 0)
-                return;
-            Value = new Vector3(parameterValues[0].UnboxToFloat(), parameterValues[1].UnboxToFloat(), parameterValues[2].UnboxToFloat());
+            var x = 0f;
+            var y = 0f;
+            var z = 0f;
+            
+            if (parameterValues.Count == 1)
+            {
+                x = parameterValues[0].UnboxToFloat();
+                y = parameterValues[0].UnboxToFloat();
+                z = parameterValues[0].UnboxToFloat();
+            }
+            else if (parameterValues.Count == 2)
+            {
+                x = parameterValues[0].UnboxToFloat();
+                y = parameterValues[1].UnboxToFloat();
+            }
+            else if (parameterValues.Count == 3)
+            {
+                x = parameterValues[0].UnboxToFloat();
+                y = parameterValues[1].UnboxToFloat();
+                z = parameterValues[2].UnboxToFloat();
+            }
+
+            Value = new Vector3(x, y, z);
         }
 
         public CustomLogicVector3Builtin(Vector3 value): base("Vector3")
@@ -175,6 +195,11 @@ namespace CustomLogic
                 return false;
             var other = ((CustomLogicVector3Builtin)obj).Value;
             return Value == other;
+        }
+
+        public override string ToString()
+        {
+            return Value.ToString();
         }
     }
 }

--- a/Assets/Scripts/CustomLogic/CustomLogicEvaluator.cs
+++ b/Assets/Scripts/CustomLogic/CustomLogicEvaluator.cs
@@ -817,8 +817,16 @@ namespace CustomLogic
             {
                 if (left is int && right is int)
                     return (int)left + (int)right;
-                else if (left is string && right is string)
-                    return (string)left + (string)right;
+
+                var leftStr = left is string;
+                var rightStr = right is string;
+                if (leftStr || rightStr)
+                {
+                    if (leftStr)
+                        return (string)left + right;
+
+                    return left + (string)right;
+                }
                 else if (left is CustomLogicVector3Builtin && right is CustomLogicVector3Builtin)
                     return new CustomLogicVector3Builtin(((CustomLogicVector3Builtin)left).Value + ((CustomLogicVector3Builtin)right).Value);
                 else


### PR DESCRIPTION
Some QoL improvements for custom logic.

### Extra constructor overloads
- Vector3
	- `Vector3()` 
	- `Vector3(xyz: float)`
	- `Vector3(x: float, y: float)`
	- `Vector3(x: float, y: float, z: float)`
- Color
	- `Color()` 
	- `Color(hex: string)`
	- `Color(r: int, g: int, b: int)`
	- `Color(r: int, g: int, b: int, a: int)`

### Override `ToString` for some of the built-in types
- `Vector3`
- `Color`
- `Quaternion`
- `List`
- `Dict`

### Auto convert to string
When adding (`+` operator) a non-string type to a string type, the non-string type will be automatically converted to string. Previously this code would throw an `InvalidCastExcpetion`, but now it is valid: 
```
a = 30;
b = 15.0;
c = a + b;
d = "c is " + c;
Game.Print(d); 
# prints "c is 45" #
```