### PR TITLE
Spawn Orientation

### DIFF
--- a/Assets/Scripts/Cameras/InGameCamera.cs
+++ b/Assets/Scripts/Cameras/InGameCamera.cs
@@ -94,7 +94,9 @@ namespace Cameras
             else
                 _anchorDistance = _heightDistance = 1f;
             if (resetRotation)
-                Cache.Transform.rotation = Quaternion.Euler(0f, 0f, 0f);
+                Cache.Transform.rotation = character.IsMine()
+                    ? Util.ConstrainedToY(_follow.Cache.Transform.rotation)
+                    : Quaternion.Euler(0f, 0f, 0f);
             if (character is Human && character.IsMine())
                 _menu.HUDBottomHandler.SetBottomHUD((Human)character);
             else

--- a/Assets/Scripts/Characters/Human/Human.cs
+++ b/Assets/Scripts/Characters/Human/Human.cs
@@ -722,11 +722,12 @@ namespace Characters
             SetInterpolation(true);
             if (IsMine())
             {
+                TargetAngle = Cache.Transform.eulerAngles.y;
                 Cache.PhotonView.RPC("SetupRPC", RpcTarget.AllBuffered, Setup.CustomSet.SerializeToJsonString(), (int)Setup.Weapon);
                 LoadSkin();
                 if (SettingsManager.InGameCurrent.Misc.Horses.Value)
                 {
-                    Horse = (Horse)CharacterSpawner.Spawn(CharacterPrefabs.Horse, Cache.Transform.position + Vector3.right * 2f, Util.ConstrainedToY(Cache.Transform.rotation));
+                    Horse = (Horse)CharacterSpawner.Spawn(CharacterPrefabs.Horse, Cache.Transform.position + Vector3.right * 2f, Quaternion.Euler(0f, TargetAngle, 0f));
                     Horse.Init(this);
                 }
                 if (DebugTesting.DebugPhase)

--- a/Assets/Scripts/Characters/Human/Human.cs
+++ b/Assets/Scripts/Characters/Human/Human.cs
@@ -466,7 +466,7 @@ namespace Characters
 
         public void TransformShifter(string shifter, float liveTime)
         {
-            _inGameManager.SpawnPlayerShifterAt(shifter, liveTime, Cache.Transform.position);
+            _inGameManager.SpawnPlayerShifterAt(shifter, liveTime, Cache.Transform.position, Cache.Transform.rotation);
             ((BaseShifter)_inGameManager.CurrentCharacter).PreviousHumanGas = CurrentGas;
             ((BaseShifter)_inGameManager.CurrentCharacter).PreviousHumanWeapon = Weapon;
             PhotonNetwork.Destroy(gameObject);

--- a/Assets/Scripts/Characters/Human/Human.cs
+++ b/Assets/Scripts/Characters/Human/Human.cs
@@ -466,7 +466,7 @@ namespace Characters
 
         public void TransformShifter(string shifter, float liveTime)
         {
-            _inGameManager.SpawnPlayerShifterAt(shifter, liveTime, Cache.Transform.position, Cache.Transform.rotation);
+            _inGameManager.SpawnPlayerShifterAt(shifter, liveTime, Cache.Transform.position, Cache.Transform.rotation.eulerAngles.y);
             ((BaseShifter)_inGameManager.CurrentCharacter).PreviousHumanGas = CurrentGas;
             ((BaseShifter)_inGameManager.CurrentCharacter).PreviousHumanWeapon = Weapon;
             PhotonNetwork.Destroy(gameObject);

--- a/Assets/Scripts/Characters/Human/Human.cs
+++ b/Assets/Scripts/Characters/Human/Human.cs
@@ -722,11 +722,11 @@ namespace Characters
             SetInterpolation(true);
             if (IsMine())
             {
-                Cache.PhotonView.RPC("SetupRPC", RpcTarget.AllBuffered, new object[] { Setup.CustomSet.SerializeToJsonString(), (int)Setup.Weapon });
+                Cache.PhotonView.RPC("SetupRPC", RpcTarget.AllBuffered, Setup.CustomSet.SerializeToJsonString(), (int)Setup.Weapon);
                 LoadSkin();
                 if (SettingsManager.InGameCurrent.Misc.Horses.Value)
                 {
-                    Horse = (Horse)CharacterSpawner.Spawn(CharacterPrefabs.Horse, Cache.Transform.position + Vector3.right * 2f, Quaternion.identity);
+                    Horse = (Horse)CharacterSpawner.Spawn(CharacterPrefabs.Horse, Cache.Transform.position + Vector3.right * 2f, Util.ConstrainedToY(Cache.Transform.rotation));
                     Horse.Init(this);
                 }
                 if (DebugTesting.DebugPhase)

--- a/Assets/Scripts/Characters/Shifters/BaseShifter.cs
+++ b/Assets/Scripts/Characters/Shifters/BaseShifter.cs
@@ -83,7 +83,7 @@ namespace Characters
             Cache.PhotonView.RPC("MarkDeadRPC", RpcTarget.AllBuffered, new object[0]);
             StartCoroutine(WaitAndDie());
             yield return new WaitForSeconds(2f);
-            _inGameManager.SpawnPlayerAt(false, BaseTitanCache.Neck.position);
+            _inGameManager.SpawnPlayerAt(false, BaseTitanCache.Neck.position, BaseTitanCache.Neck.rotation);
             Human currentCharacter = ((Human)(_inGameManager.CurrentCharacter));
             currentCharacter.StartCoroutine(currentCharacter.WaitAndTransformFromShifter(PreviousHumanGas, PreviousHumanWeapon));
         }

--- a/Assets/Scripts/Characters/Shifters/BaseShifter.cs
+++ b/Assets/Scripts/Characters/Shifters/BaseShifter.cs
@@ -79,12 +79,12 @@ namespace Characters
         protected IEnumerator WaitAndBecomeHuman(float time)
         {
             yield return new WaitForSeconds(time);
-            Cache.PhotonView.RPC("MarkTransformingRPC", RpcTarget.AllBuffered, new object[0]);
-            Cache.PhotonView.RPC("MarkDeadRPC", RpcTarget.AllBuffered, new object[0]);
+            Cache.PhotonView.RPC("MarkTransformingRPC", RpcTarget.AllBuffered);
+            Cache.PhotonView.RPC("MarkDeadRPC", RpcTarget.AllBuffered);
             StartCoroutine(WaitAndDie());
             yield return new WaitForSeconds(2f);
-            _inGameManager.SpawnPlayerAt(false, BaseTitanCache.Neck.position, BaseTitanCache.Neck.rotation);
-            Human currentCharacter = ((Human)(_inGameManager.CurrentCharacter));
+            _inGameManager.SpawnPlayerAt(false, BaseTitanCache.Neck.position, BaseTitanCache.Neck.rotation.eulerAngles.y);
+            Human currentCharacter = ((Human)_inGameManager.CurrentCharacter);
             currentCharacter.StartCoroutine(currentCharacter.WaitAndTransformFromShifter(PreviousHumanGas, PreviousHumanWeapon));
         }
 

--- a/Assets/Scripts/CustomLogic/Builtin/CustomLogicGameBuiltin.cs
+++ b/Assets/Scripts/CustomLogic/Builtin/CustomLogicGameBuiltin.cs
@@ -75,7 +75,7 @@ namespace CustomLogic
             {
                 string type = (string)parameters[0];
                 Vector3 position = ((CustomLogicVector3Builtin)parameters[1]).Value;
-                float rotationY = parameters.Count > 2 ? (float)parameters[2] : 0f;
+                float rotationY = parameters.Count > 2 ? parameters[2].UnboxToFloat() : 0f;
                 if (PhotonNetwork.IsMasterClient)
                 {
                     var titan = new CustomLogicTitanBuiltin(gameManager.SpawnAITitanAt(type, position, rotationY));
@@ -106,7 +106,7 @@ namespace CustomLogic
             {
                 string type = (string)parameters[0];
                 Vector3 position = ((CustomLogicVector3Builtin)parameters[2]).Value;
-                float rotationY = parameters.Count > 3 ? (float)parameters[3] : 0f;
+                float rotationY = parameters.Count > 3 ? parameters[3].UnboxToFloat() : 0f;
                 if (PhotonNetwork.IsMasterClient)
                 {
                     CustomLogicListBuiltin list = new CustomLogicListBuiltin();
@@ -123,7 +123,7 @@ namespace CustomLogic
             {
                 string type = (string)parameters[0];
                 Vector3 position = ((CustomLogicVector3Builtin)parameters[2]).Value;
-                float rotationY = parameters.Count > 3 ? (float)parameters[3] : 0f;
+                float rotationY = parameters.Count > 3 ? parameters[3].UnboxToFloat() : 0f;
                 if (PhotonNetwork.IsMasterClient)
                     gameManager.SpawnAITitansAtAsync(type, (int)parameters[1], position, rotationY);
                 return null;
@@ -142,7 +142,7 @@ namespace CustomLogic
             {
                 string type = (string)parameters[0];
                 Vector3 position = ((CustomLogicVector3Builtin)parameters[1]).Value;
-                float rotationY = parameters.Count > 2 ? (float)parameters[2] : 0f;
+                float rotationY = parameters.Count > 2 ? parameters[2].UnboxToFloat() : 0f;
                 if (PhotonNetwork.IsMasterClient)
                 {
                     var shifter = new CustomLogicShifterBuiltin(gameManager.SpawnAIShifterAt(type, position, rotationY));
@@ -243,7 +243,7 @@ namespace CustomLogic
                 var player = ((CustomLogicPlayerBuiltin)parameters[0]).Player;
                 bool force = (bool)parameters[1];
                 Vector3 position = ((CustomLogicVector3Builtin)parameters[2]).Value;
-                float rotationY = parameters.Count > 3 ? (float)parameters[3] : 0f;
+                float rotationY = parameters.Count > 3 ? parameters[3].UnboxToFloat() : 0f;
                 if (player == PhotonNetwork.LocalPlayer)
                     gameManager.SpawnPlayerAt(force, position, rotationY);
                 else if (PhotonNetwork.IsMasterClient)
@@ -254,7 +254,7 @@ namespace CustomLogic
             {
                 bool force = (bool)parameters[0];
                 Vector3 position = ((CustomLogicVector3Builtin)parameters[1]).Value;
-                float rotationY = parameters.Count > 2 ? (float)parameters[2] : 0f;
+                float rotationY = parameters.Count > 2 ? parameters[2].UnboxToFloat() : 0f;
                 if (PhotonNetwork.IsMasterClient)
                     RPCManager.PhotonView.RPC("SpawnPlayerAtRPC", RpcTarget.All, force, position, rotationY);
                 return null;

--- a/Assets/Scripts/CustomLogic/Builtin/CustomLogicGameBuiltin.cs
+++ b/Assets/Scripts/CustomLogic/Builtin/CustomLogicGameBuiltin.cs
@@ -75,9 +75,10 @@ namespace CustomLogic
             {
                 string type = (string)parameters[0];
                 Vector3 position = ((CustomLogicVector3Builtin)parameters[1]).Value;
+                Quaternion rotation = parameters.Count > 2 ? ((CustomLogicQuaternionBuiltin) parameters[2]).Value : Quaternion.identity;
                 if (PhotonNetwork.IsMasterClient)
                 {
-                    var titan = new CustomLogicTitanBuiltin(gameManager.SpawnAITitanAt(type, position));
+                    var titan = new CustomLogicTitanBuiltin(gameManager.SpawnAITitanAt(type, position, rotation));
                     return titan;
                 }
                 return null;
@@ -105,12 +106,13 @@ namespace CustomLogic
             {
                 string type = (string)parameters[0];
                 Vector3 position = ((CustomLogicVector3Builtin)parameters[2]).Value;
+                Quaternion rotation = parameters.Count > 3 ? ((CustomLogicQuaternionBuiltin) parameters[3]).Value : Quaternion.identity;
                 if (PhotonNetwork.IsMasterClient)
                 {
                     CustomLogicListBuiltin list = new CustomLogicListBuiltin();
                     for (int i = 0; i < (int)parameters[1]; i++)
                     {
-                        var titan = new CustomLogicTitanBuiltin(gameManager.SpawnAITitanAt(type, position));
+                        var titan = new CustomLogicTitanBuiltin(gameManager.SpawnAITitanAt(type, position, rotation));
                         list.List.Add(titan);
                     }
                     return list;
@@ -139,9 +141,10 @@ namespace CustomLogic
             {
                 string type = (string)parameters[0];
                 Vector3 position = ((CustomLogicVector3Builtin)parameters[1]).Value;
+                Quaternion rotation = parameters.Count > 2 ? ((CustomLogicQuaternionBuiltin) parameters[2]).Value : Quaternion.identity;
                 if (PhotonNetwork.IsMasterClient)
                 {
-                    var shifter = new CustomLogicShifterBuiltin(gameManager.SpawnAIShifterAt(type, position));
+                    var shifter = new CustomLogicShifterBuiltin(gameManager.SpawnAIShifterAt(type, position, rotation));
                     return shifter;
                 }
                 return null;

--- a/Assets/Scripts/CustomLogic/Builtin/CustomLogicGameBuiltin.cs
+++ b/Assets/Scripts/CustomLogic/Builtin/CustomLogicGameBuiltin.cs
@@ -242,18 +242,20 @@ namespace CustomLogic
                 var player = ((CustomLogicPlayerBuiltin)parameters[0]).Player;
                 bool force = (bool)parameters[1];
                 Vector3 position = ((CustomLogicVector3Builtin)parameters[2]).Value;
+                Quaternion rotation = parameters.Count > 3 ? ((CustomLogicQuaternionBuiltin)parameters[3]).Value : Quaternion.identity;
                 if (player == PhotonNetwork.LocalPlayer)
-                    gameManager.SpawnPlayerAt(force, position);
+                    gameManager.SpawnPlayerAt(force, position, rotation);
                 else if (PhotonNetwork.IsMasterClient)
-                    RPCManager.PhotonView.RPC("SpawnPlayerAtRPC", player, new object[] { force, position });
+                    RPCManager.PhotonView.RPC("SpawnPlayerAtRPC", player, force, position, rotation);
                 return null;
             }
             if (name == "SpawnPlayerAtAll")
             {
                 bool force = (bool)parameters[0];
                 Vector3 position = ((CustomLogicVector3Builtin)parameters[1]).Value;
+                Quaternion rotation = parameters.Count > 2 ? ((CustomLogicQuaternionBuiltin)parameters[2]).Value : Quaternion.identity;
                 if (PhotonNetwork.IsMasterClient)
-                    RPCManager.PhotonView.RPC("SpawnPlayerAtRPC", RpcTarget.All, new object[] { force, position });
+                    RPCManager.PhotonView.RPC("SpawnPlayerAtRPC", RpcTarget.All, force, position, rotation);
                 return null;
             }
             if (name == "SetPlaylist")

--- a/Assets/Scripts/CustomLogic/Builtin/CustomLogicGameBuiltin.cs
+++ b/Assets/Scripts/CustomLogic/Builtin/CustomLogicGameBuiltin.cs
@@ -75,10 +75,10 @@ namespace CustomLogic
             {
                 string type = (string)parameters[0];
                 Vector3 position = ((CustomLogicVector3Builtin)parameters[1]).Value;
-                Quaternion rotation = parameters.Count > 2 ? ((CustomLogicQuaternionBuiltin) parameters[2]).Value : Quaternion.identity;
+                float rotationY = parameters.Count > 2 ? (float)parameters[2] : 0f;
                 if (PhotonNetwork.IsMasterClient)
                 {
-                    var titan = new CustomLogicTitanBuiltin(gameManager.SpawnAITitanAt(type, position, rotation));
+                    var titan = new CustomLogicTitanBuiltin(gameManager.SpawnAITitanAt(type, position, rotationY));
                     return titan;
                 }
                 return null;
@@ -106,13 +106,13 @@ namespace CustomLogic
             {
                 string type = (string)parameters[0];
                 Vector3 position = ((CustomLogicVector3Builtin)parameters[2]).Value;
-                Quaternion rotation = parameters.Count > 3 ? ((CustomLogicQuaternionBuiltin) parameters[3]).Value : Quaternion.identity;
+                float rotationY = parameters.Count > 3 ? (float)parameters[3] : 0f;
                 if (PhotonNetwork.IsMasterClient)
                 {
                     CustomLogicListBuiltin list = new CustomLogicListBuiltin();
                     for (int i = 0; i < (int)parameters[1]; i++)
                     {
-                        var titan = new CustomLogicTitanBuiltin(gameManager.SpawnAITitanAt(type, position, rotation));
+                        var titan = new CustomLogicTitanBuiltin(gameManager.SpawnAITitanAt(type, position, rotationY));
                         list.List.Add(titan);
                     }
                     return list;
@@ -123,8 +123,9 @@ namespace CustomLogic
             {
                 string type = (string)parameters[0];
                 Vector3 position = ((CustomLogicVector3Builtin)parameters[2]).Value;
+                float rotationY = parameters.Count > 3 ? (float)parameters[3] : 0f;
                 if (PhotonNetwork.IsMasterClient)
-                    gameManager.SpawnAITitansAtAsync(type, (int)parameters[1], position);
+                    gameManager.SpawnAITitansAtAsync(type, (int)parameters[1], position, rotationY);
                 return null;
             }
             if (name == "SpawnShifter")
@@ -141,10 +142,10 @@ namespace CustomLogic
             {
                 string type = (string)parameters[0];
                 Vector3 position = ((CustomLogicVector3Builtin)parameters[1]).Value;
-                Quaternion rotation = parameters.Count > 2 ? ((CustomLogicQuaternionBuiltin) parameters[2]).Value : Quaternion.identity;
+                float rotationY = parameters.Count > 2 ? (float)parameters[2] : 0f;
                 if (PhotonNetwork.IsMasterClient)
                 {
-                    var shifter = new CustomLogicShifterBuiltin(gameManager.SpawnAIShifterAt(type, position, rotation));
+                    var shifter = new CustomLogicShifterBuiltin(gameManager.SpawnAIShifterAt(type, position, rotationY));
                     return shifter;
                 }
                 return null;
@@ -234,7 +235,7 @@ namespace CustomLogic
             {
                 bool force = (bool)parameters[0];
                 if (PhotonNetwork.IsMasterClient)
-                    RPCManager.PhotonView.RPC("SpawnPlayerRPC", RpcTarget.All, new object[] { force });
+                    RPCManager.PhotonView.RPC("SpawnPlayerRPC", RpcTarget.All, new { force });
                 return null;
             }
             if (name == "SpawnPlayerAt")
@@ -242,20 +243,20 @@ namespace CustomLogic
                 var player = ((CustomLogicPlayerBuiltin)parameters[0]).Player;
                 bool force = (bool)parameters[1];
                 Vector3 position = ((CustomLogicVector3Builtin)parameters[2]).Value;
-                Quaternion rotation = parameters.Count > 3 ? ((CustomLogicQuaternionBuiltin)parameters[3]).Value : Quaternion.identity;
+                float rotationY = parameters.Count > 3 ? (float)parameters[3] : 0f;
                 if (player == PhotonNetwork.LocalPlayer)
-                    gameManager.SpawnPlayerAt(force, position, rotation);
+                    gameManager.SpawnPlayerAt(force, position, rotationY);
                 else if (PhotonNetwork.IsMasterClient)
-                    RPCManager.PhotonView.RPC("SpawnPlayerAtRPC", player, force, position, rotation);
+                    RPCManager.PhotonView.RPC("SpawnPlayerAtRPC", player, force, position, rotationY);
                 return null;
             }
             if (name == "SpawnPlayerAtAll")
             {
                 bool force = (bool)parameters[0];
                 Vector3 position = ((CustomLogicVector3Builtin)parameters[1]).Value;
-                Quaternion rotation = parameters.Count > 2 ? ((CustomLogicQuaternionBuiltin)parameters[2]).Value : Quaternion.identity;
+                float rotationY = parameters.Count > 2 ? (float)parameters[2] : 0f;
                 if (PhotonNetwork.IsMasterClient)
-                    RPCManager.PhotonView.RPC("SpawnPlayerAtRPC", RpcTarget.All, force, position, rotation);
+                    RPCManager.PhotonView.RPC("SpawnPlayerAtRPC", RpcTarget.All, force, position, rotationY);
                 return null;
             }
             if (name == "SetPlaylist")

--- a/Assets/Scripts/GameManagers/InGameManager.cs
+++ b/Assets/Scripts/GameManagers/InGameManager.cs
@@ -342,22 +342,24 @@ namespace GameManagers
             if (PhotonNetwork.LocalPlayer.HasSpawnPoint())
             {
                 var position = PhotonNetwork.LocalPlayer.GetSpawnPoint();
-                SpawnPlayerAt(force, position, Quaternion.identity);
+                SpawnPlayerAt(force, position, 0f);
             }
             else if (isHuman)
             {
                 var (position, rotation) = GetHumanSpawnPoint();
-                SpawnPlayerAt(force, position, rotation);
+                SpawnPlayerAt(force, position, rotation.eulerAngles.y);
             }
             else
             {
                 var (position, rotation) = GetTitanSpawnPoint();
-                SpawnPlayerAt(force, position, rotation);
+                SpawnPlayerAt(force, position, rotation.eulerAngles.y);
             }
         }
 
-        public void SpawnPlayerShifterAt(string shifterName, float liveTime, Vector3 position, Quaternion rotation)
+        public void SpawnPlayerShifterAt(string shifterName, float liveTime, Vector3 position, float rotationY)
         {
+            var rotation = Quaternion.Euler(0f, rotationY, 0f);
+            
             if (shifterName == "Annie")
             {
                 var shifter = (AnnieShifter)CharacterSpawner.Spawn(CharacterPrefabs.AnnieShifter, position, rotation);
@@ -378,8 +380,10 @@ namespace GameManagers
             }
         }
 
-        public void SpawnPlayerAt(bool force, Vector3 position, Quaternion rotation)
+        public void SpawnPlayerAt(bool force, Vector3 position, float rotationY)
         {
+            var rotation = Quaternion.Euler(0f, rotationY, 0f);
+            
             if (!IsFinishedLoading())
                 return;
             var settings = SettingsManager.InGameCharacterSettings;
@@ -426,12 +430,12 @@ namespace GameManagers
                 CurrentCharacter = human;
             }
             else if (character == PlayerCharacter.Shifter)
-                SpawnPlayerShifterAt(settings.Loadout.Value, 0f, position, rotation);
+                SpawnPlayerShifterAt(settings.Loadout.Value, 0f, position, rotationY);
             else if (character == PlayerCharacter.Titan)
             {
                 int[] combo = BasicTitanSetup.GetRandomBodyHeadCombo();
                 string prefab = CharacterPrefabs.BasicTitanPrefix + combo[0];
-                var titan = (BasicTitan)CharacterSpawner.Spawn(prefab, position, Quaternion.identity);
+                var titan = (BasicTitan)CharacterSpawner.Spawn(prefab, position, rotation);
                 titan.Init(false, GetPlayerTeam(true), null, combo[1]);
                 SetupTitan(titan);
                 float smallSize = 1f;
@@ -493,12 +497,12 @@ namespace GameManagers
         public BasicTitan SpawnAITitan(string type)
         {
             var spawn = GetTitanSpawnPoint();
-            return SpawnAITitanAt(type, spawn.position, spawn.rotation);
+            return SpawnAITitanAt(type, spawn.position, spawn.rotation.eulerAngles.y);
         }
 
         public IEnumerable<BasicTitan> SpawnAITitans(string type, int count)
         {
-            return GetTitanSpawnPositions(count).Select(p => SpawnAITitanAt(type, p.position, p.rotation));
+            return GetTitanSpawnPositions(count).Select(p => SpawnAITitanAt(type, p.position, p.rotation.eulerAngles.y));
         }
 
         public void SpawnAITitansAsync(string type, int count)
@@ -511,24 +515,22 @@ namespace GameManagers
             var randomPositions = GetTitanSpawnPositions(count);
             foreach (var spawn in randomPositions)
             {
-                SpawnAITitanAt(type, spawn.position, spawn.rotation);
+                SpawnAITitanAt(type, spawn.position, spawn.rotation.eulerAngles.y);
                 yield return new WaitForEndOfFrame();
                 yield return new WaitForEndOfFrame();
             }
         }
 
-        public void SpawnAITitansAtAsync(string type, int count, Vector3 position, Quaternion rotation = default)
+        public void SpawnAITitansAtAsync(string type, int count, Vector3 position, float rotationY)
         {
-            if (rotation == default) rotation = Quaternion.identity;
-            
-            StartCoroutine(SpawnAITitansAtCoroutine(type, count, position, rotation));
+            StartCoroutine(SpawnAITitansAtCoroutine(type, count, position, rotationY));
         }
 
-        private IEnumerator SpawnAITitansAtCoroutine(string type, int count, Vector3 position, Quaternion rotation)
+        private IEnumerator SpawnAITitansAtCoroutine(string type, int count, Vector3 position, float rotationY)
         {
             for (int i = 0; i < count; i++)
             {
-                SpawnAITitanAt(type, position, rotation);
+                SpawnAITitanAt(type, position, rotationY);
                 yield return new WaitForEndOfFrame();
                 yield return new WaitForEndOfFrame();
             }
@@ -547,8 +549,10 @@ namespace GameManagers
                 : Enumerable.Repeat((Vector3.zero,  Quaternion.identity), count);
         }
 
-        public BasicTitan SpawnAITitanAt(string type, Vector3 position, Quaternion rotation)
+        public BasicTitan SpawnAITitanAt(string type, Vector3 position, float rotationY)
         {
+            var rotation = Quaternion.Euler(0f, rotationY, 0f);
+            
             if (type == "Default")
             {
                 var settings = SettingsManager.InGameCurrent.Titan;
@@ -577,7 +581,7 @@ namespace GameManagers
             }
             var data = CharacterData.GetTitanAI((GameDifficulty)SettingsManager.InGameCurrent.General.Difficulty.Value, type);
             int[] combo = BasicTitanSetup.GetRandomBodyHeadCombo(data);
-            string prefab = CharacterPrefabs.BasicTitanPrefix + combo[0].ToString();
+            string prefab = CharacterPrefabs.BasicTitanPrefix + combo[0];
             var titan = (BasicTitan)CharacterSpawner.Spawn(prefab, position, rotation);
             titan.Init(true, TeamInfo.Titan, data, combo[1]);
             SetupTitan(titan);
@@ -630,11 +634,13 @@ namespace GameManagers
         public BaseShifter SpawnAIShifter(string type)
         {
             var spawn = GetTitanSpawnPoint();
-            return SpawnAIShifterAt(type, spawn.position, spawn.rotation);
+            return SpawnAIShifterAt(type, spawn.position, spawn.rotation.eulerAngles.y);
         }
 
-        public BaseShifter SpawnAIShifterAt(string type, Vector3 position, Quaternion rotation)
+        public BaseShifter SpawnAIShifterAt(string type, Vector3 position, float rotationY)
         {
+            var rotation = Quaternion.Euler(0f, rotationY, 0f);
+            
             string prefab = "";
             if (type == "Annie")
                 prefab = CharacterPrefabs.AnnieShifter;

--- a/Assets/Scripts/GameManagers/RPCManager.cs
+++ b/Assets/Scripts/GameManagers/RPCManager.cs
@@ -201,11 +201,11 @@ namespace GameManagers
         }
 
         [PunRPC]
-        public void SpawnPlayerAtRPC(bool force, Vector3 position, Quaternion rotation, PhotonMessageInfo info)
+        public void SpawnPlayerAtRPC(bool force, Vector3 position, float rotationY, PhotonMessageInfo info)
         {
             if (info.Sender.IsMasterClient)
             {
-                ((InGameManager)SceneLoader.CurrentGameManager).SpawnPlayerAt(force, position, rotation);
+                ((InGameManager)SceneLoader.CurrentGameManager).SpawnPlayerAt(force, position, rotationY);
             }
         }
 

--- a/Assets/Scripts/GameManagers/RPCManager.cs
+++ b/Assets/Scripts/GameManagers/RPCManager.cs
@@ -201,11 +201,11 @@ namespace GameManagers
         }
 
         [PunRPC]
-        public void SpawnPlayerAtRPC(bool force, Vector3 position, PhotonMessageInfo info)
+        public void SpawnPlayerAtRPC(bool force, Vector3 position, Quaternion rotation, PhotonMessageInfo info)
         {
             if (info.Sender.IsMasterClient)
             {
-                ((InGameManager)SceneLoader.CurrentGameManager).SpawnPlayerAt(force, position);
+                ((InGameManager)SceneLoader.CurrentGameManager).SpawnPlayerAt(force, position, rotation);
             }
         }
 

--- a/Assets/Scripts/Map/MapManager.cs
+++ b/Assets/Scripts/Map/MapManager.cs
@@ -42,6 +42,22 @@ namespace Map
             xform = null;
             return false;
         }
+        
+        public static bool TryGetRandomTagsXform(List<string> tags, out Transform xform)
+        {
+            foreach (string tag in tags)
+            {
+                var go = GetRandomTag(tag);
+                if (go)
+                {
+                    xform = go.transform;
+                    return true;
+                }
+            }
+
+            xform = null;
+            return false;
+        }
 
         /// <summary>
         /// <para>Outputs a list of <paramref name="count"/> randomly chosen objects with a given tag within avoidance parameters.</para>
@@ -77,18 +93,7 @@ namespace Map
             }
             return true;
         }
-
-        public static Vector3 GetRandomTagsPosition(List<string> tags, Vector3 defaultPosition)
-        {
-            foreach (string tag in tags)
-            {
-                GameObject go = GetRandomTag(tag);
-                if (go != null)
-                    return go.transform.position;
-            }
-            return defaultPosition;
-        }
-
+        
         public static GameObject GetRandomTag(string tag)
         {
             if (MapLoader.Tags.ContainsKey(tag))

--- a/Assets/Scripts/Utility/Util.cs
+++ b/Assets/Scripts/Utility/Util.cs
@@ -276,5 +276,14 @@ namespace Utility
 
             return paginatedCommands;
         }
+        
+        public static Quaternion ConstrainedToX(Quaternion rotation) =>
+            Quaternion.Euler(rotation.eulerAngles.x, 0f,  0f);
+        
+        public static Quaternion ConstrainedToY(Quaternion rotation) =>
+            Quaternion.Euler(0f, rotation.eulerAngles.y,  0f);
+        
+        public static Quaternion ConstrainedToZ(Quaternion rotation) =>
+            Quaternion.Euler(0f, 0f,  rotation.eulerAngles.z);
     }
 }


### PR DESCRIPTION
Humans and titans can now be spawned with any rotation around the Y-axis.

**Changes**
1. Titan spawn points determine the initial rotation of AI titans.
2. Human spawn points determine the initial rotation of humans.
3. The CL Spawn functions have an extra parameter for rotation around the Y-axis in degrees.
4. Horses should now spawn facing the same direction as the player. (Not tested.)

**Not included**
When spawning a player, if `PhotonNetwork.LocalPlayer.HasSpawnPoint() == true`, rotation is always `Quaternion.identity`. I think this may apply to racing maps, but I'm not sure. We could modify how this spawn point is parsed, so that rotation can be included. Here's the current parsing code:
```cs
var property = player.GetStringProperty(PlayerProperty.SpawnPoint, "0,0,0");
var strArr = property.Split(',');
return new Vector3(float.Parse(strArr[0]), float.Parse(strArr[1]), float.Parse(strArr[2]));
```