### PR TITLE
fix/gas sound when killed and air dodge when wall sliding

### DIFF
--- a/Assets/Scripts/Characters/Human/Human.cs
+++ b/Assets/Scripts/Characters/Human/Human.cs
@@ -1231,6 +1231,11 @@ namespace Characters
                 if (State == HumanState.Grab || Dead)
                 {
                     Cache.Rigidbody.velocity = Vector3.zero;
+                    if (IsPlayingSound(HumanSounds.GasLoop))
+                    {
+                        StopSound(HumanSounds.GasLoop);
+                        ToggleSound(HumanSounds.GasEnd, true);
+                    }                     
                     return;
                 }
                 if (CarryState == HumanCarryState.Carry)

--- a/Assets/Scripts/Characters/Human/Human.cs
+++ b/Assets/Scripts/Characters/Human/Human.cs
@@ -390,11 +390,20 @@ namespace Characters
                 Vector3 direction = GetTargetDirection();
                 _originalDashSpeed = Cache.Rigidbody.velocity.magnitude;
                 _targetRotation = GetTargetRotation();
-                Cache.Rigidbody.rotation = _targetRotation;
+                if(!_wallSlide)
+                {
+                    //The line below was causing problems when dashing away from walls at certain angles.
+                    //Removing it fixed that but I'm unsure if it's needed for another situation (didn't notice a difference without it), do uncomment if the case
+                    //Cache.Rigidbody.rotation = _targetRotation;
+                    CrossFade(HumanAnimations.Dash, 0.1f, 0.1f);
+                }
+                   
+                else
+                    PlayAnimation(HumanAnimations.Dodge, 0.2f);           
                 EffectSpawner.Spawn(EffectPrefabs.GasBurst, Cache.Transform.position, Cache.Transform.rotation);
                 PlaySound(HumanSounds.GasBurst);
                 _dashTimeLeft = 0.5f;
-                CrossFade(HumanAnimations.Dash, 0.1f, 0.1f);
+                
                 State = HumanState.AirDodge;
                 FalseAttack();
                 Cache.Rigidbody.AddForce(direction * 40f, ForceMode.VelocityChange);


### PR DESCRIPTION
- Fixes a bug where the gas sound was still playing after the player got grabbed or died
- Fixes a bug where air dodging out of a wall slide caused the player to not dash away
- Player now plays the dodge animation when air dodging out of a wall slide