### PR TITLE
Fix issue #113 (PM command only sending first word of message)

### DIFF
--- a/Assets/Scripts/GameManagers/ChatManager.cs
+++ b/Assets/Scripts/GameManagers/ChatManager.cs
@@ -274,8 +274,12 @@ namespace GameManagers
             var player = GetPlayer(args);
             if (args.Length > 2 && player != null)
             {
-                SendChat("From " + PhotonNetwork.LocalPlayer.GetStringProperty(PlayerProperty.Name) + ": " + args[2], player);
-                AddLine("To " + player.GetStringProperty(PlayerProperty.Name) + ": " + args[2]);
+                string[] msgArgs = new string[args.Length - 2];
+                Array.ConstrainedCopy(args, 2, msgArgs, 0, msgArgs.Length);
+                string message = string.Join(' ', msgArgs);
+
+                SendChat("From " + PhotonNetwork.LocalPlayer.GetStringProperty(PlayerProperty.Name) + ": " + message, player);
+                AddLine("To " + player.GetStringProperty(PlayerProperty.Name) + ": " + message);
             }
         }
 


### PR DESCRIPTION
Modified `PrivateMessage` in [ChatManager.cs](Assets/Scripts/GameManagers/ChatManager.cs) to use an array copy that starts from the 3rd index of `args`, then calling `string.Join` to construct the final message.

Closes issue #113 .