### PR TITLE
Added new utility method GetInGameMousePosition for handling differen…

### DIFF
--- a/Assets/Scripts/Characters/BaseCharacter.cs
+++ b/Assets/Scripts/Characters/BaseCharacter.cs
@@ -90,7 +90,7 @@ namespace Characters
 
         public virtual Vector3 GetAimPoint()
         {
-            Ray ray = SceneLoader.CurrentCamera.Camera.ScreenPointToRay(Input.mousePosition);
+            Ray ray = SceneLoader.CurrentCamera.Camera.ScreenPointToRay(CursorManager.GetInGameMousePosition());
             Vector3 target = ray.origin + ray.direction * 1000f;
             return target;
         }

--- a/Assets/Scripts/Characters/Human/Human.cs
+++ b/Assets/Scripts/Characters/Human/Human.cs
@@ -160,7 +160,7 @@ namespace Characters
 
         public Ray GetAimRayAfterHuman()
         {
-            Ray ray = SceneLoader.CurrentCamera.Camera.ScreenPointToRay(Input.mousePosition);
+            Ray ray = SceneLoader.CurrentCamera.Camera.ScreenPointToRay(CursorManager.GetInGameMousePosition());
 
             // Define a plane at the characters position facing towards the camera's forward direction
             Plane plane = new Plane(ray.direction, Cache.Transform.position);
@@ -181,7 +181,7 @@ namespace Characters
 
         public Ray GetAimRayAfterHumanCheap()
         {
-            Ray ray = SceneLoader.CurrentCamera.Camera.ScreenPointToRay(Input.mousePosition);
+            Ray ray = SceneLoader.CurrentCamera.Camera.ScreenPointToRay(CursorManager.GetInGameMousePosition());
             // Move the ray origin along its direction by the distance between the ray origin and the character
             ray.origin = ray.GetPoint(Vector3.Distance(ray.origin, HumanCache.Head.transform.position));
 
@@ -2040,7 +2040,7 @@ namespace Characters
 
         public void FixedUpdateLookTitan()
         {
-            Ray ray = SceneLoader.CurrentCamera.Camera.ScreenPointToRay(Input.mousePosition);
+            Ray ray = SceneLoader.CurrentCamera.Camera.ScreenPointToRay(CursorManager.GetInGameMousePosition());
             LayerMask mask = PhysicsLayer.GetMask(PhysicsLayer.EntityDetection);
             RaycastHit[] hitArr = Physics.RaycastAll(ray, 200f, mask.value);
             if (hitArr.Length == 0)
@@ -2733,7 +2733,7 @@ namespace Characters
 
         private string GetBladeAnimationMouse()
         {
-            if (Input.mousePosition.x < (Screen.width * 0.5))
+            if (CursorManager.GetInGameMousePosition().x < (Screen.width * 0.5))
                 return HumanAnimations.Attack2;
             else
                 return HumanAnimations.Attack1;

--- a/Assets/Scripts/Controllers/BasePlayerController.cs
+++ b/Assets/Scripts/Controllers/BasePlayerController.cs
@@ -116,7 +116,7 @@ namespace Controllers
         {
             float angleX = 0f;
             float angleY = 0f;
-            Vector3 aim = SceneLoader.CurrentCamera.Camera.ScreenPointToRay(Input.mousePosition).direction.normalized * 1000f;
+            Vector3 aim = SceneLoader.CurrentCamera.Camera.ScreenPointToRay(CursorManager.GetInGameMousePosition()).direction.normalized * 1000f;
             angleY = Mathf.Asin(aim.y / aim.magnitude) * Mathf.Rad2Deg;
             aim.y = 0f;
             angleX = -Mathf.Atan2(aim.z, aim.x) * Mathf.Rad2Deg;

--- a/Assets/Scripts/Controllers/HumanPlayerController.cs
+++ b/Assets/Scripts/Controllers/HumanPlayerController.cs
@@ -97,7 +97,7 @@ namespace Controllers
 
         protected override void UpdateUI(bool inMenu)
         {
-            Ray ray = SceneLoader.CurrentCamera.Camera.ScreenPointToRay(Input.mousePosition);
+            Ray ray = SceneLoader.CurrentCamera.Camera.ScreenPointToRay(CursorManager.GetInGameMousePosition());
             RaycastHit hit;
             string str = string.Empty;
             string distance = "???";
@@ -167,8 +167,9 @@ namespace Controllers
 
         Quaternion GetHookArrowRotation(bool left, Vector3 position)
         {
-            float x = position.x - Input.mousePosition.x;
-            float y = position.y - Input.mousePosition.y;
+            Vector3 mousePosition = CursorManager.GetInGameMousePosition();
+            float x = position.x - mousePosition.x;
+            float y = position.y - mousePosition.y;
             float z = Mathf.Atan2(y, x) * Mathf.Rad2Deg;
             return Quaternion.Euler(0, 0, z);
         }
@@ -412,7 +413,7 @@ namespace Controllers
                     {
                         if (_human.Stats.Perks["OmniDash"].CurrPoints == 1)
                         {
-                            Vector3 direction = SceneLoader.CurrentCamera.Camera.ScreenPointToRay(Input.mousePosition).direction.normalized;
+                            Vector3 direction = SceneLoader.CurrentCamera.Camera.ScreenPointToRay(CursorManager.GetInGameMousePosition()).direction.normalized;
                             _human.DashVertical(GetTargetAngle(direction), direction);
                         }
                         else if (_human.Stats.Perks["VerticalDash"].CurrPoints == 1)
@@ -422,7 +423,7 @@ namespace Controllers
                                 angle += 360f;
                             if (angle >= 360f)
                                 angle -= 360f;
-                            Vector3 direction = SceneLoader.CurrentCamera.Camera.ScreenPointToRay(Input.mousePosition).direction.normalized;
+                            Vector3 direction = SceneLoader.CurrentCamera.Camera.ScreenPointToRay(CursorManager.GetInGameMousePosition()).direction.normalized;
                             if (angle > 0f && angle < 180f)
                                 _human.DashVertical(GetTargetAngle(direction), Vector3.down);
                             else

--- a/Assets/Scripts/CustomLogic/Builtin/CustomLogicInputBuiltin.cs
+++ b/Assets/Scripts/CustomLogic/Builtin/CustomLogicInputBuiltin.cs
@@ -46,7 +46,7 @@ namespace CustomLogic
             if (name == "GetMouseAim")
             {
                 RaycastHit hit;
-                Ray ray = SceneLoader.CurrentCamera.Camera.ScreenPointToRay(Input.mousePosition);
+                Ray ray = SceneLoader.CurrentCamera.Camera.ScreenPointToRay(CursorManager.GetInGameMousePosition());
                 Vector3 target = ray.origin + ray.direction * 1000f;
                 if (Physics.Raycast(ray, out hit, 1000f, Human.AimMask.value))
                     target = hit.point;

--- a/Assets/Scripts/UI/CursorManager.cs
+++ b/Assets/Scripts/UI/CursorManager.cs
@@ -227,24 +227,26 @@ namespace UI
                     crosshairImage = crosshairImageRed;
                 }
                 crosshairLabel.text = _instance._crosshairText;
-                Vector3 mousePosition = Input.mousePosition;
                 Transform crosshairTransform = crosshairImage.transform;
-                if (crosshairTransform.position != mousePosition)
+                if (crosshairTransform.position != Input.mousePosition)
                 {
-                    var cameraMode = ((InGameCamera)SceneLoader.CurrentCamera).CurrentCameraMode;
-                    if (cameraMode == CameraInputMode.TPS || cameraMode == CameraInputMode.FPS)
-                    {
-                        if (Math.Abs(crosshairTransform.position.x - mousePosition.x) > 1f || Math.Abs(crosshairTransform.position.y - mousePosition.y) > 1f)
-                        {
-                            crosshairTransform.position = mousePosition;
-                        }
-                    }
-                    else
-                    {
-                        crosshairTransform.position = mousePosition;
-                    }
+                    crosshairTransform.position = GetInGameMousePosition();
                 }
                 _instance._forceNextCrosshairUpdate = false;
+            }
+        }
+
+        public static Vector3 GetInGameMousePosition()
+        {
+            switch (((InGameCamera)SceneLoader.CurrentCamera).CurrentCameraMode)
+            {
+                case CameraInputMode.TPS:
+                case CameraInputMode.FPS:
+                    return new Vector3(Screen.width * 0.5f, Screen.height * 0.5f);
+
+                case CameraInputMode.Original:
+                default:
+                    return Input.mousePosition;
             }
         }
     }


### PR DESCRIPTION
The current character control logic relies on the operating system mouse location for hooking, bursting, animations, ect. In TPS and FPS camera modes, the operating system cursor is locked to the center of the screen. A dead-zone is used to prevent jittering as the cursor isn't always perfectly in the center.

The current logic works for Windows and Mac but breaks for Linux due to a [known issue](https://discussions.unity.com/t/cursor-lockstate-locked-still-reaching-screen-edges-on-linux-unity-2022-3/1489329) in Unity 2022+. This PR fixes the TPS and FPS cameras for Linux by substituting in the the screen center for the operating system mouse position. Additionally, the dead-zone is no longer needed.

New changes were validated on Windows and Linux. The following features were tested and working:

- Crosshair arrows
- Omni-directional burst
- Titan player attacks
- Blade throw
- AHSS attacks
- Thunderspear
- Spin special
- Flare
- Blade animation (left vs right)
- Custom logic "GetMouseAim" function
- Hook arrow rotation
- Distance meter