### PR TITLE
Allow players to vote kick other players

### DIFF
--- a/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
+++ b/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
@@ -128,6 +128,8 @@ MonoBehaviour:
   - ResetKDRPC
   - SetInputVolumeRPC
   - DecreaseAttackSpeedRPC
+  - VoteKickRPC
+  - AnnounceRPC
   DisableAutoOpenWizard: 1
   ShowSettings: 1
   DevRegionSetOnce: 1

--- a/Assets/Scripts/Anticheat/AnticheatManager.cs
+++ b/Assets/Scripts/Anticheat/AnticheatManager.cs
@@ -1,11 +1,8 @@
 using ApplicationManagers;
 using Events;
-using GameManagers;
 using Photon.Realtime;
 using Photon.Pun;
-using Settings;
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using Utility;
@@ -15,7 +12,10 @@ namespace Anticheat
     class AnticheatManager : MonoBehaviour
     {
         private static AnticheatManager _instance;
-        private Dictionary<int, Dictionary<PhotonEventType, BaseEventFilter>> _IdToEventFilters = new Dictionary<int, Dictionary<PhotonEventType, BaseEventFilter>>();
+        private static readonly Dictionary<int, Dictionary<PhotonEventType, BaseEventFilter>> _IdToEventFilters = new();
+        private static readonly Dictionary<Player, HashSet<Vote>> VotesByTargetPlayer = new();
+        private static readonly List<Player> removals = new();
+        private static readonly TimeSpan VoteTimeout = TimeSpan.FromMinutes(5.0);
 
         public static void Init()
         {
@@ -23,16 +23,13 @@ namespace Anticheat
             EventManager.OnLoadScene += OnLoadScene;
         }
 
-        private static void OnLoadScene(SceneName sceneName)
-        {
-            _instance._IdToEventFilters.Clear();
-        }
+        private static void OnLoadScene(SceneName sceneName) => _IdToEventFilters.Clear();
 
         public static bool CheckPhotonEvent(Player sender, PhotonEventType eventType, object[] data)
         {
-            if (!_instance._IdToEventFilters.ContainsKey(sender.ActorNumber))
-                _instance._IdToEventFilters.Add(sender.ActorNumber, new Dictionary<PhotonEventType, BaseEventFilter>());
-            var filters = _instance._IdToEventFilters[sender.ActorNumber];
+            if (!_IdToEventFilters.ContainsKey(sender.ActorNumber))
+                _IdToEventFilters.Add(sender.ActorNumber, new Dictionary<PhotonEventType, BaseEventFilter>());
+            var filters = _IdToEventFilters[sender.ActorNumber];
             if (!filters.ContainsKey(eventType))
             {
                 if (eventType == PhotonEventType.Instantiate)
@@ -57,11 +54,81 @@ namespace Anticheat
                 DebugConsole.Log("Player " + player.ActorNumber.ToString() + " was autobanned. Reason:" + reason, true);
             }
         }
+
+
+        public static bool TryVoteKickPlayer(Player voter, Player target, out (int submitted, int required) progress)
+        {
+            HashSet<Vote> votes = null;
+            if (target != PhotonNetwork.LocalPlayer)
+            {
+                if (VotesByTargetPlayer.TryGetValue(target, out votes))
+                    votes.Add(voter);
+                else
+                    VotesByTargetPlayer.Add(target, votes = new HashSet<Vote> { voter });
+            }
+
+            progress.submitted = votes != null ? votes.Count : 0;
+            progress.required = PhotonNetwork.CurrentRoom.PlayerCount / 2 + 1;
+            if (progress.submitted >= progress.required)
+            {
+                KickPlayer(target);
+                VotesByTargetPlayer.Remove(target);
+                return true;
+            }
+
+            return false;
+        }
+
+        public static void ResetVoteKicks(Player player)
+        {
+            foreach (var voters in VotesByTargetPlayer.Values)
+                voters.Remove(player);
+        }
+
+        private static void RemoveOldVotes()
+        {
+            foreach (var kvp in VotesByTargetPlayer)
+            {
+                var target = kvp.Key;
+                var votes = kvp.Value;
+                votes.RemoveWhere(vote => DateTime.UtcNow - vote.Timestamp > VoteTimeout);
+                if (votes.Count == 0) removals.Add(target);
+            }
+
+            foreach (var target in removals)
+                VotesByTargetPlayer.Remove(target);
+
+            removals.Clear();
+        }
     }
 
     public enum PhotonEventType
     {
         Instantiate,
         RPC
+    }
+
+    readonly struct Vote
+    {
+        public readonly Player Voter;
+        public readonly DateTime Timestamp;
+
+        public Vote(Player player)
+        {
+            Voter = player;
+            Timestamp = DateTime.UtcNow;
+        }
+
+        public override int GetHashCode() => Voter.GetHashCode();
+
+        public override bool Equals(object obj)
+        {
+            if (obj is not Vote other) return false;
+            return Voter.Equals(other.Voter);
+        }
+
+        public override string ToString() => $"{Voter} ({Timestamp})";
+
+        public static implicit operator Vote(Player voter) => new(voter);
     }
 }

--- a/Assets/Scripts/Anticheat/AnticheatManager.cs
+++ b/Assets/Scripts/Anticheat/AnticheatManager.cs
@@ -58,6 +58,8 @@ namespace Anticheat
 
         public static bool TryVoteKickPlayer(Player voter, Player target, out (int submitted, int required) progress)
         {
+            RemoveOldVotes();
+
             HashSet<Vote> votes = null;
             if (target != PhotonNetwork.LocalPlayer)
             {

--- a/Assets/Scripts/GameManagers/ChatManager.cs
+++ b/Assets/Scripts/GameManagers/ChatManager.cs
@@ -470,10 +470,10 @@ namespace GameManagers
             if (!PhotonNetwork.IsMasterClient) return;
             if (!SettingsManager.InGameCurrent.Misc.AllowVoteKicking.Value) return;
 
-            var success = AnticheatManager.TryVoteKickPlayer(voter, target, out var progress);
-            var msg = GetColorString($"Voted to kick {target.GetStringProperty(PlayerProperty.Name)} {progress.submitted}/{progress.required}.", ChatTextColor.System);
+            var result = AnticheatManager.TryVoteKickPlayer(voter, target);
+            var msg = result.ToString();
             RPCManager.PhotonView.RPC(nameof(RPCManager.AnnounceRPC), voter, new object[] { msg });
-            if (success)
+            if (result.IsSuccess)
                 SendChatAll(target.GetStringProperty(PlayerProperty.Name) + " has been vote kicked.", ChatTextColor.System);
         }
 

--- a/Assets/Scripts/GameManagers/InGameManager.cs
+++ b/Assets/Scripts/GameManagers/InGameManager.cs
@@ -17,6 +17,7 @@ using System.IO;
 using System.Linq;
 using Controllers;
 using Photon.Voice.PUN;
+using Anticheat;
 
 namespace GameManagers
 {
@@ -327,6 +328,7 @@ namespace GameManagers
             if (VoiceChatVolumeMultiplier.ContainsKey(player.ActorNumber))
                 VoiceChatVolumeMultiplier.Remove(player.ActorNumber);
 
+            AnticheatManager.ResetVoteKicks(player);
         }
 
         public override void OnMasterClientSwitched(Player newMasterClient)

--- a/Assets/Scripts/GameManagers/RPCManager.cs
+++ b/Assets/Scripts/GameManagers/RPCManager.cs
@@ -248,6 +248,20 @@ namespace GameManagers
         }
 
         [PunRPC]
+        public void AnnounceRPC(string message, PhotonMessageInfo info)
+        {
+            ChatManager.OnAnnounceRPC(message);
+        }
+
+        [PunRPC]
+        public void VoteKickRPC(int id, PhotonMessageInfo info)
+        {
+            var voter = info.Sender;
+            var target = PhotonNetwork.CurrentRoom.GetPlayer(id, false);
+            ChatManager.VoteKickPlayer(voter, target);
+        }
+
+        [PunRPC]
         public void TestRPC(Color c)
         {
             Debug.Log(c);

--- a/Assets/Scripts/Settings/InGame/InGameMiscSettings.cs
+++ b/Assets/Scripts/Settings/InGame/InGameMiscSettings.cs
@@ -18,6 +18,7 @@ namespace Settings
         public BoolSetting AllowPlayerTitans = new BoolSetting(true);
         public BoolSetting AllowShifterSpecials = new BoolSetting(true);
         public BoolSetting AllowShifters = new BoolSetting(false);
+        public BoolSetting AllowVoteKicking = new BoolSetting(false);
         public BoolSetting Horses = new BoolSetting(false);
         public BoolSetting GunsAirReload = new BoolSetting(true);
         public BoolSetting AllowStock = new BoolSetting(true);

--- a/Assets/Scripts/UI/CreateGamePopup/CreateGameGeneralPanel.cs
+++ b/Assets/Scripts/UI/CreateGamePopup/CreateGameGeneralPanel.cs
@@ -81,6 +81,7 @@ namespace UI
             misc.AllowPlayerTitans.Value = true;
             misc.AllowShifterSpecials.Value = true;
             misc.AllowShifters.Value = false;
+            misc.AllowVoteKicking.Value = false;
             misc.Horses.Value = false;
             misc.APGPVP.Value = false;
             misc.RealismMode.Value = false;

--- a/Assets/Scripts/UI/CreateGamePopup/CreateGameMiscPanel.cs
+++ b/Assets/Scripts/UI/CreateGamePopup/CreateGameMiscPanel.cs
@@ -40,6 +40,7 @@ namespace UI
             ElementFactory.CreateToggleSetting(DoublePanelRight, style, settings.AllowPlayerTitans, UIManager.GetLocale(cat, sub, "AllowPlayerTitans"));
             ElementFactory.CreateToggleSetting(DoublePanelRight, style, settings.AllowShifters, UIManager.GetLocale(cat, sub, "AllowShifters"));
             ElementFactory.CreateToggleSetting(DoublePanelRight, style, settings.AllowShifterSpecials, UIManager.GetLocale(cat, sub, "AllowShifterSpecials"));
+            ElementFactory.CreateToggleSetting(DoublePanelRight, style, settings.AllowVoteKicking, UIManager.GetLocale(cat, sub, "AllowVoteKicking"));
             ElementFactory.CreateToggleSetting(DoublePanelRight, style, settings.ClearKDROnRestart, UIManager.GetLocale(cat, sub, "ClearKDROnRestart"));
             ElementFactory.CreateToggleSetting(DoublePanelRight, style, settings.GlobalMinimapDisable, UIManager.GetLocale(cat, sub, "GlobalMinimapDisable"));
             ElementFactory.CreateDropdownSetting(DoublePanelRight, style, settings.VoiceChat, UIManager.GetLocale(cat, sub, "VoiceChat"), 

--- a/Assets/StreamingAssets/Languages/English.json
+++ b/Assets/StreamingAssets/Languages/English.json
@@ -156,6 +156,7 @@
 		"Misc.AllowPlayerTitans": "Allow player titans",
 		"Misc.AllowShifters": "Allow shifters",
 		"Misc.AllowShifterSpecials": "Allow shifter specials",
+		"Misc.AllowVoteKicking": "Allow vote kicking",
 		"Misc.Horses": "Horses",
 		"Misc.HorseSpeed": "Horse speed",
 		"Misc.GunsAirReload": "Guns air reload",


### PR DESCRIPTION
Hosts can now enable vote kicking in the server settings under "Misc".

When enabled, a player who is not Master Client uses the `/kick` command, the decision is left up to a vote.
The player gets a message from the server that they voted, with information on how many votes have been cast and how many are required.
The server keeps track of who voted for the player, and once enough votes (more than half the lobby) have been cast, the player is kicked with an appropriate message.

If a voting player leaves, their vote is retracted.
Votes are also retracted after a period of 5 minutes.

Players cannot vote for themselves or the Master Client.

Votes cannot be cast more than once per minute, and only one vote can be active at a time.