### PR TITLE
Fixed titan explode not killing non-host players

### DIFF
--- a/Assets/Resources/Data/Modes/Titan ExplodeLogic.txt
+++ b/Assets/Resources/Data/Modes/Titan ExplodeLogic.txt
@@ -38,8 +38,16 @@ class Main
         {
             if (Vector3.Distance(human.Position, position) < self.ExplodeRadius)
             {
-                human.GetKilled("Explosion");
+                Network.SendMessage(human.Player, "die");
             }
+        }
+    }
+
+    function OnNetworkMessage(sender, message)
+    {
+        if (message == "die")
+        {
+            Network.MyPlayer.Character.GetKilled("Explosion");
         }
     }
 


### PR DESCRIPTION
Fixed by sending a message to the player so that they can kill themselves. Calling `GetKilled` from host's side does not work