### PR TITLE
Mapobject as spawnpoint

### DIFF
--- a/Assets/Resources/Data/Modes/BaseLogic.txt
+++ b/Assets/Resources/Data/Modes/BaseLogic.txt
@@ -2026,7 +2026,7 @@ component RacingCheckpointRegion
             {
                 other.PlaySound("Checkpoint");
             }
-            other.Player.SpawnPoint = self.MapObject.Position;
+            other.Player.SpawnPoint = self.MapObject;
         }
     }
 }

--- a/Assets/Scripts/CustomLogic/Builtin/CustomLogicPlayerBuiltin.cs
+++ b/Assets/Scripts/CustomLogic/Builtin/CustomLogicPlayerBuiltin.cs
@@ -117,9 +117,18 @@ namespace CustomLogic
                     Player.SetCustomProperty(PlayerProperty.SpawnPoint, "null");
                 else
                 {
-                    Vector3 vector = ((CustomLogicVector3Builtin)value).Value;
-                    string str = string.Join(",", new string[] { vector.x.ToString(), vector.y.ToString(), vector.z.ToString() });
-                    Player.SetCustomProperty(PlayerProperty.SpawnPoint, str);
+                    if (value is CustomLogicVector3Builtin v3)
+                    {
+                        var vector = v3.Value;
+                        string str = string.Join(",", new string[] { vector.x.ToString(), vector.y.ToString(), vector.z.ToString() });
+                        Player.SetCustomProperty(PlayerProperty.SpawnPoint, str);
+                    }
+                    else if (value is CustomLogicMapObjectBuiltin mapObject)
+                    {
+                        Player.SetCustomProperty(PlayerProperty.SpawnPoint, mapObject.Value.ScriptObject.Id.ToString());
+                    }
+                    else
+                        Player.SetCustomProperty(PlayerProperty.SpawnPoint, "null");
                 }
             }
             else

--- a/Assets/Scripts/CustomLogic/CustomLogicUtils.cs
+++ b/Assets/Scripts/CustomLogic/CustomLogicUtils.cs
@@ -11,7 +11,7 @@ namespace CustomLogic
             if (ast is CustomLogicPrimitiveExpressionAst primitiveAst)
             {
                 if (primitiveAst.Value is float or int)
-                    return primitiveAst.ToString();
+                    return primitiveAst.Value.ToString();
                 else if (primitiveAst.Value is bool b)
                     return b ? "true" : "false";
                 else if (primitiveAst.Value is string s)

--- a/Assets/Scripts/Utility/Extensions/PhotonExtensions.cs
+++ b/Assets/Scripts/Utility/Extensions/PhotonExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using GameManagers;
+using Map;
 using Photon.Realtime;
 using System;
 using System.Collections.Generic;
@@ -94,13 +95,24 @@ static class PhotonExtensions
     public static bool HasSpawnPoint(this Player player)
     {
         var property = player.GetStringProperty(PlayerProperty.SpawnPoint, "null");
-        return property != "null" && property.Contains(",");
+        return property != "null";
     }
 
     public static Vector3 GetSpawnPoint(this Player player)
     {
+        var position = Vector3.zero;
         var property = player.GetStringProperty(PlayerProperty.SpawnPoint, "0,0,0");
-        var strArr = property.Split(',');
-        return new Vector3(float.Parse(strArr[0]), float.Parse(strArr[1]), float.Parse(strArr[2]));
+
+        if (property.Contains(","))
+        {
+            var strArr = property.Split(',');
+            position = new Vector3(float.Parse(strArr[0]), float.Parse(strArr[1]), float.Parse(strArr[2]));
+        }
+        else
+        {
+            if (MapLoader.IdToMapObject.TryGetValue(int.Parse(property), out MapObject mapObject))
+                position = mapObject.GameObject.transform.position;
+        }
+        return position;
     }
 }


### PR DESCRIPTION
- Checkpoint sets the map object as the player's spawn point, this solves the issue with moving checkpoints
- Made a silly mistake when I pushed changes for AddComponent, fixed that