### PR TITLE
AHSS - Shooting Bug Fix

### DIFF
--- a/Assets/Scripts/UI/CreateGamePopup/CreateGamePopup.cs
+++ b/Assets/Scripts/UI/CreateGamePopup/CreateGamePopup.cs
@@ -119,7 +119,7 @@ namespace UI
             {
                 case "Restart":
                     InGameManager.RestartGame();
-                    ((InGameMenu)UIManager.CurrentMenu).SkipAHSSInput = true; // Prevents AHSS players from shooting when leaving the character change menu saving one extra round
+                    ((InGameMenu)UIManager.CurrentMenu).SkipAHSSInput = true; // Prevents AHSS players from shooting when restarting the map/level
                     break;
                 case "Start":
                     MusicManager.PlayEffect();

--- a/Assets/Scripts/UI/CreateGamePopup/CreateGamePopup.cs
+++ b/Assets/Scripts/UI/CreateGamePopup/CreateGamePopup.cs
@@ -119,6 +119,7 @@ namespace UI
             {
                 case "Restart":
                     InGameManager.RestartGame();
+                    ((InGameMenu)UIManager.CurrentMenu).SkipAHSSInput = true; // Prevents AHSS players from shooting when leaving the character change menu saving one extra round
                     break;
                 case "Start":
                     MusicManager.PlayEffect();

--- a/Assets/Scripts/UI/InGameMenu/CharacterChangePopup.cs
+++ b/Assets/Scripts/UI/InGameMenu/CharacterChangePopup.cs
@@ -29,6 +29,7 @@ namespace UI
 
         private void OnBottomBarButtonClick(string name)
         {
+            ((InGameMenu)UIManager.CurrentMenu).SkipAHSSInput = true; // Prevents AHSS players from shooting when leaving the character change menu saving one extra round
             var manager = (InGameManager)SceneLoader.CurrentGameManager;
             switch (name)
             {

--- a/Assets/Scripts/UI/InGameMenu/InGameMenu.cs
+++ b/Assets/Scripts/UI/InGameMenu/InGameMenu.cs
@@ -287,7 +287,6 @@ namespace UI
                     _characterChangePopup = ElementFactory.CreateDefaultPopup<CharacterChangePopup>(transform);
                     _popups.Add(_characterChangePopup);
                 }
-                SkipAHSSInput = true;
                 _characterChangePopup.Show();
             }
         }

--- a/Assets/Scripts/UI/InGameMenu/InGameMenu.cs
+++ b/Assets/Scripts/UI/InGameMenu/InGameMenu.cs
@@ -287,6 +287,7 @@ namespace UI
                     _characterChangePopup = ElementFactory.CreateDefaultPopup<CharacterChangePopup>(transform);
                     _popups.Add(_characterChangePopup);
                 }
+                SkipAHSSInput = true;
                 _characterChangePopup.Show();
             }
         }


### PR DESCRIPTION
Fix for AHSS that had it shooting whenever the character change pop up was closed or when the round was restarted. It is only activated on button click and shouldn't interfere with other logic. Was tested by Hao and deemed solved