### PR TITLE
Compilation error fixes

### DIFF
--- a/Assets/Scripts/Characters/Human/Specials/SupplySpecial.cs
+++ b/Assets/Scripts/Characters/Human/Specials/SupplySpecial.cs
@@ -3,7 +3,6 @@ using GameManagers;
 using System.Collections;
 using UnityEngine;
 using Spawnables;
-using static UnityEditor.IMGUI.Controls.PrimitiveBoundsHandle;
 
 namespace Characters
 {

--- a/Assets/Scripts/Scripts.asmdef
+++ b/Assets/Scripts/Scripts.asmdef
@@ -16,6 +16,7 @@
         "GUID:df380645f10b7bc4b97d4f5eb6303d95",
         "GUID:46a67ded66a63de48b9329c593fc08de",
         "GUID:de1079f91ae5b43499b7c7e4f1269884",
+        "GUID:be0903cd8e1546f498710afdc59db5eb",
         "GUID:ade7125e800904674ba0c115208f7ed5",
         "GUID:21b0c8d1703a94250bfac916590cea4f",
         "GUID:f10496e9d78b943308af5e7e9e4543c8",


### PR DESCRIPTION
The recent pull request for creating assembly files caused build issues: [PR #142](https://github.com/AoTTG-2/Aottg2-Unity/pull/142)
This PR fixes the errors. The build now succeeds with no errors.
- Removed problematic import statement for `UnityEngine.IMGUI.Controls.PrimitiveBoundsHandle`
- Added missing assembly reference for ShaderGraph.Editor

![Unused import](https://github.com/user-attachments/assets/b4d5e1b4-51e2-47dd-9c99-97fc47a0bda6)
![Shader errors](https://github.com/user-attachments/assets/c8d65350-aae2-4fdc-826e-e1c0cc7ecc6a)
