### PR TITLE
Resetting Escape Ability

### DIFF
--- a/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
+++ b/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
@@ -130,6 +130,7 @@ MonoBehaviour:
   - DecreaseAttackSpeedRPC
   - VoteKickRPC
   - AnnounceRPC
+  - ConfirmCarryRPC
   DisableAutoOpenWizard: 1
   ShowSettings: 1
   DevRegionSetOnce: 1

--- a/Assets/Scripts/Characters/BaseUseable/BaseUseable.cs
+++ b/Assets/Scripts/Characters/BaseUseable/BaseUseable.cs
@@ -9,6 +9,7 @@ namespace Characters
     abstract class BaseUseable
     {
         public float Cooldown;
+        public float ReduceCooldownAmount;
         public int UsesLeft;
         public int MaxUses;
         public bool IsActive;
@@ -16,10 +17,11 @@ namespace Characters
         protected float _lastUseTime = -1000f;
         protected BaseCharacter _owner;
 
-        public BaseUseable(BaseCharacter owner, float cooldown = 0f, int maxUses = -1)
+        public BaseUseable(BaseCharacter owner, float cooldown = 0f, float _reduceCooldownAmount =0f,int maxUses = -1)
         {
             _owner = owner;
             Cooldown = cooldown;
+            ReduceCooldownAmount = _reduceCooldownAmount;
             UsesLeft = MaxUses = maxUses;
         }
 
@@ -31,17 +33,18 @@ namespace Characters
         {
             UsesLeft = MaxUses;
         }
-
         public void SetCooldownLeft(float cooldownLeft)
         {
             _lastUseTime = Time.time - Cooldown + cooldownLeft;
         }
-
+        public void ReduceCooldown()
+        {
+            _lastUseTime -= ReduceCooldownAmount;
+        }
         public float GetCooldownLeft()
         {
             return Mathf.Clamp(Cooldown - (Time.time - _lastUseTime), 0f, Cooldown);
         }
-
         public float GetCooldownRatio()
         {
             if (!HasUsesLeft())
@@ -67,7 +70,10 @@ namespace Characters
         {
             return (Time.time - _lastUseTime) >= Cooldown && (UsesLeft == -1 || UsesLeft > 0);
         }
-
+        public virtual bool HasDurability()
+        {
+            return false;
+        }
         protected virtual void OnUse()
         {
             if (UsesLeft > 0)

--- a/Assets/Scripts/Characters/Human/Human.cs
+++ b/Assets/Scripts/Characters/Human/Human.cs
@@ -1039,7 +1039,6 @@ namespace Characters
             else
                 base.GetHitRPC(viewId, name, damage, type, collider);
         }
-
         public override void OnHit(BaseHitbox hitbox, object victim, Collider collider, string type, bool firstHit)
         {
             if (hitbox != null)
@@ -1163,6 +1162,10 @@ namespace Characters
                             }
 
                         }
+                        if (GetCurrentSpecial() is EscapeSpecial)
+                        {
+                            ReduceSpecialCooldown();
+                        }
                         _lastNapeHitTimes[titan] = Time.time;
                     }
                     if (titan.BaseTitanCache.Hurtboxes.Contains(collider))
@@ -1181,7 +1184,6 @@ namespace Characters
                 }
             }
         }
-
         protected void Update()
         {
             if (IsMine() && !Dead)
@@ -2515,7 +2517,15 @@ namespace Characters
             Special = HumanSpecials.GetSpecialUseable(this, special);
             ((InGameMenu)UIManager.CurrentMenu).HUDBottomHandler.SetSpecialIcon(HumanSpecials.GetSpecialIcon(special));
         }
-
+        public BaseUseable GetCurrentSpecial()
+        {
+            return Special;
+        }
+        public void ReduceSpecialCooldown()
+        {
+            Special.ReduceCooldown();
+        }
+        
         protected void LoadSkin(Player player = null)
         {
             if (IsMine())

--- a/Assets/Scripts/Characters/Human/Weapons/AmmoWeapon.cs
+++ b/Assets/Scripts/Characters/Human/Weapons/AmmoWeapon.cs
@@ -63,10 +63,13 @@ namespace Characters
             if (RoundLeft >= 0)
                 RoundLeft--;
         }
-
         public override bool CanUse()
         {
             return base.CanUse() && (RoundLeft > 0 || RoundLeft == -1);
+        }
+        public override bool HasDurability()
+        {
+            return (RoundLeft > 0 || RoundLeft == -1);
         }
     }
 }

--- a/Assets/Scripts/Characters/Human/Weapons/BladeWeapon.cs
+++ b/Assets/Scripts/Characters/Human/Weapons/BladeWeapon.cs
@@ -41,6 +41,10 @@ namespace Characters
         {
             return base.CanUse() && CurrentDurability > 0f && ((Human)_owner).State == HumanState.Idle;
         }
+        public override bool HasDurability()
+        {
+            return CurrentDurability > 0f;
+        }
 
         protected override void Activate()
         {

--- a/Assets/Scripts/Projectiles/ThunderspearProjectile.cs
+++ b/Assets/Scripts/Projectiles/ThunderspearProjectile.cs
@@ -169,7 +169,10 @@ namespace Projectiles
                             ((InGameCamera)SceneLoader.CurrentCamera).TakeSnapshot(titan.BaseTitanCache.Neck.position, damage);
                             titan.GetHit(_owner, damage, "Thunderspear", collider.name);
                         }
-
+                        if(((Human)_owner).GetCurrentSpecial() is EscapeSpecial)
+                        {
+                            ((Human)_owner).ReduceSpecialCooldown();
+                        }
                         if (titan.CurrentHealth <= 0)
                             soundPriority = Mathf.Max(soundPriority, (int)TSKillType.Kill);
                         else


### PR DESCRIPTION
Added ReduceCooldownAmount to BaseUsable's constructor default value is 0f. It can be used if we want to reduce cooldown based on any condition. It's only used in EscapeSpecial for now.  Also added HasDurability to BaseUsable and than override this in both AmmoWeapon and BladeWeapon. Main reason i did this is BladeWeapon.CanUse() is also looking for HumanState.Idle and this disables blade weapon to use escape special. Escape Special has 300s cooldown, 50f ReduceCooldownAmount and its unable to use at start.