### PR TITLE
Nape Lock Improvements

### DIFF
--- a/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
+++ b/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
@@ -130,6 +130,7 @@ MonoBehaviour:
   - DecreaseAttackSpeedRPC
   - VoteKickRPC
   - AnnounceRPC
+  - ConfirmCarryRPC
   DisableAutoOpenWizard: 1
   ShowSettings: 1
   DevRegionSetOnce: 1

--- a/Assets/Scripts/UI/CursorManager.cs
+++ b/Assets/Scripts/UI/CursorManager.cs
@@ -114,10 +114,17 @@ namespace UI
                 State = CursorState.Crosshair;
             }
             var cameraMode = ((InGameCamera)SceneLoader.CurrentCamera).CurrentCameraMode;
+            var isNapeLocked = ((InGameCamera)SceneLoader.CurrentCamera)._napeLock;
             if (cameraMode == CameraInputMode.TPS || cameraMode == CameraInputMode.FPS)
             {
-                if (Cursor.lockState != CursorLockMode.Locked)
+                if (Cursor.lockState != CursorLockMode.Locked && !isNapeLocked)
+                {
                     Cursor.lockState = CursorLockMode.Locked;
+                }
+                else
+                {
+                    Cursor.lockState = CursorLockMode.Confined;
+                }
             }
             else if (Cursor.lockState != CursorLockMode.Confined)
                 Cursor.lockState = CursorLockMode.Confined;


### PR DESCRIPTION
Now, the camera can be moved up and down while the nape lock is engaged. After killing the target, you had to press the nape lock button twice to lock it again. This was improved by setting the '_napeLock' boolean to false when the target is killed. Some unnecessary assignments removed and repeating code lines merged.