### PR TITLE
Use XDG_DATA_HOME to store settings & data on Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ bin/
 obj/
 .suo
 
+# Visual Studio Code
+.vscode/
+
 # Gradle cache directory
 .gradle/
 

--- a/Assets/Scripts/Utility/FolderPaths.cs
+++ b/Assets/Scripts/Utility/FolderPaths.cs
@@ -6,7 +6,10 @@ namespace Utility
 {
     class FolderPaths
     {
-        public static string Documents = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments) + "/Aottg2";
+        // MyDocuments returns $HOME on Linux, use XDG_DATA_HOME instead
+        public static string Documents = Application.platform == RuntimePlatform.LinuxPlayer
+        ? Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) + "/Aottg2"
+        : Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments) + "/Aottg2";
         public static string StreamingAssetsPath = Application.streamingAssetsPath;
         public static string LanguagesPath = StreamingAssetsPath + "/Languages";
         public static string TesterData = StreamingAssetsPath + "/TesterData";


### PR DESCRIPTION
Currently the game puts all of its data in `$HOME/Aottg2/` on Linux, which is generally frowned upon as it needlessly clutters the user's home directory. This is a very minor fix to change the storage path to better adhere to the XDG Base Directory specification for storing application data. Now the default storage path is `$HOME/.local/share/Aottg2/`, or the user-specified `$XDG_DATA_HOME` which aligns with how most other games handle their data.

This isn't 100% spec compliant as that would require separating settings and data into `$XDG_CONFIG_HOME` and `$XDG_DATA_HOME`, but it seems other games don't separate those either so this may be more in line with user expectations.