### PR TITLE
Automatically migrate Linux saves to the new location

### DIFF
--- a/Assets/Scripts/ApplicationManagers/ApplicationStart.cs
+++ b/Assets/Scripts/ApplicationManagers/ApplicationStart.cs
@@ -50,6 +50,11 @@ namespace ApplicationManagers
             MaterialCache.Init();
             EventManager.Init();
             HumanSetup.Init();
+            if (Application.platform == RuntimePlatform.LinuxPlayer)
+            {
+                // Linux - Data path has moved, migrate old data
+                DataMigrator.MigrateLinuxSaves();
+            }
             SettingsManager.Init();
             FullscreenHandler.Init();
             UIManager.Init();

--- a/Assets/Scripts/ApplicationManagers/ApplicationStart.cs
+++ b/Assets/Scripts/ApplicationManagers/ApplicationStart.cs
@@ -53,7 +53,14 @@ namespace ApplicationManagers
             if (Application.platform == RuntimePlatform.LinuxPlayer)
             {
                 // Linux - Data path has moved, migrate old data
-                DataMigrator.MigrateLinuxSaves();
+                try
+                {                    
+                    DataMigrator.MigrateLinuxSaves();
+                }
+                catch (System.Exception MigrationFailed)
+                {
+                    Debug.LogException(MigrationFailed);
+                }
             }
             SettingsManager.Init();
             FullscreenHandler.Init();

--- a/Assets/Scripts/Utility/DataMigrator.cs
+++ b/Assets/Scripts/Utility/DataMigrator.cs
@@ -1,0 +1,39 @@
+using System;
+using System.IO;
+
+namespace Utility
+{
+    public class DataMigrator
+    {
+        private static void CopyDirectory(DirectoryInfo source, DirectoryInfo destination)
+        {
+            foreach (FileInfo file in source.GetFiles())
+            {
+                file.CopyTo(Path.Combine(destination.FullName, file.Name), true);
+            }
+
+            foreach (DirectoryInfo directory in source.GetDirectories())
+            {
+                DirectoryInfo nextDir = destination.CreateSubdirectory(directory.Name);
+                CopyDirectory(directory, nextDir);
+            }
+        }
+
+        public static void MigrateLinuxSaves()
+        {
+            string oldPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments) + "/Aottg2";
+            string newPath = FolderPaths.Documents;
+
+            if (Directory.Exists(oldPath))
+            {
+                // Only attempt to copy if the old path exists and the new does not
+                // Avoids overwriting new data
+                FileAttributes sourceAttribs = File.GetAttributes(oldPath);
+                if (sourceAttribs == FileAttributes.Directory && !Directory.Exists(newPath))
+                {
+                    CopyDirectory(new DirectoryInfo(oldPath), new DirectoryInfo(newPath));
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Utility/DataMigrator.cs.meta
+++ b/Assets/Scripts/Utility/DataMigrator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 16685bd84f1c8d7cea4461f329a677b4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Follow-up to #175  (should probably have been part of it) to automatically copy the old saves to the new `XDG_DATA_HOME` path. It uses a new `DataMigrator` class in `Util`, which may be useful in case a similar change happens on other platforms.

There is not any data validation beyond checking if the old directory exists, and that it is a folder. It may be worth checking whether the things in the folder are ours before copying, but there is at least a check to make sure user data isn't overwritten.