### PR TITLE
Thyme halloween fixes

### DIFF
--- a/Assets/Resources/Data/Maps/Mission/Spooky WavesMap.txt
+++ b/Assets/Resources/Data/Maps/Mission/Spooky WavesMap.txt
@@ -2453,6 +2453,7 @@ Scene,FX/SpiderFX1,122009,0,1,0,1,0,SpiderFX1,-200.8807,0.5289798,-71.49068,0,0,
 Scene,FX/PumpkinFX1,122011,0,1,0,1,0,PumpkinFX1,-205.7497,0.614033,-70.03815,0,0,0,1,1,1,Physical,Entities,Default,DefaultNoTint|255/255/255/255,;
 Scene,Decor/DirtMuncherTitan1,122012,0,1,1,1,0,DirtMuncherTitan1,-251.5233,8.485835,-58.92149,82.08739,265.8485,306.7292,0.3,0.25,0.25,Physical,Entities,Default,Default|255/255/255/255,;
 Scene,General/EditorPointLight,122013,121963,1,0,0,0,PointLight,343.45,1068.565,-126.8058,0,0,0,4,4,4,None,Entities,Default,DefaultNoTint|255/255/255/255,PointLight|Color:255/0/0/255|Intensity:1|Range:100
+/// Logic
 class Main
 {   
     Description = "Survive multiple waves of spooky titans.";

--- a/Assets/Resources/Data/Maps/Mission/Spooky WavesMap.txt
+++ b/Assets/Resources/Data/Maps/Mission/Spooky WavesMap.txt
@@ -2488,21 +2488,22 @@ class Main
                 }
             }
 
+            actualHead = character.Transform.GetTransform("Head");
             head = character.HeadMount;
             ps = head.Position;
             size = character.Size;
 
             x = ps.X;
-            y = ps.Y + 8 * (size / 3);
+            y = ps.Y + 7 * (size / 3);
             z = ps.Z;
 
             rx = 0;
             ry = 90;
             rz = 0;
 
-            sx = size * 4;
-            sy = size * 4;
-            sz = size * 4;
+            sx = size * 3;
+            sy = size * 3.4;
+            sz = size * 3;
 
             # Spawn a pumpkin on the titan's head
             pos =   "" + x  + "," + y  + "," + z ;
@@ -2528,13 +2529,14 @@ class Main
             {
                 name += "d";
             }
+            head.SetRenderersEnabled(false);
+            actualHead.SetRenderersEnabled(false);
             jack = Map.CreateMapObjectRaw("Scene,"+name+",0,0,1,0,1,0,PumpkinHead,"+trs+",Physical,Entities,Default,Default|255/255/255/255");
             jack.Parent = head;
             jack.Forward = head.Forward;
 
             # Rotate jack 90 degrees to the right
-            jack.LocalRotation = Vector3(0, 90, 0);
-
+            jack.LocalRotation = Vector3(0, 90, -11);
         }
     }
 

--- a/Assets/Resources/Data/Maps/Mission/Spooky WavesMap.txt
+++ b/Assets/Resources/Data/Maps/Mission/Spooky WavesMap.txt
@@ -2453,7 +2453,6 @@ Scene,FX/SpiderFX1,122009,0,1,0,1,0,SpiderFX1,-200.8807,0.5289798,-71.49068,0,0,
 Scene,FX/PumpkinFX1,122011,0,1,0,1,0,PumpkinFX1,-205.7497,0.614033,-70.03815,0,0,0,1,1,1,Physical,Entities,Default,DefaultNoTint|255/255/255/255,;
 Scene,Decor/DirtMuncherTitan1,122012,0,1,1,1,0,DirtMuncherTitan1,-251.5233,8.485835,-58.92149,82.08739,265.8485,306.7292,0.3,0.25,0.25,Physical,Entities,Default,Default|255/255/255/255,;
 Scene,General/EditorPointLight,122013,121963,1,0,0,0,PointLight,343.45,1068.565,-126.8058,0,0,0,4,4,4,None,Entities,Default,DefaultNoTint|255/255/255/255,PointLight|Color:255/0/0/255|Intensity:1|Range:100
-/// Logic
 class Main
 {   
     Description = "Survive multiple waves of spooky titans.";
@@ -2528,7 +2527,7 @@ class Main
             {
                 name += "d";
             }
-            jack = Map.CreateMapObjectRaw("Scene,"+name+",0,0,1,0,1,0,PumpkinHead,"+trs+",None,Entities,Default,Default|255/255/255/255");
+            jack = Map.CreateMapObjectRaw("Scene,"+name+",0,0,1,0,1,0,PumpkinHead,"+trs+",Physical,Entities,Default,Default|255/255/255/255");
             jack.Parent = head;
             jack.Forward = head.Forward;
 

--- a/Assets/Resources/Data/Maps/Mission/Spooky WavesMap.txt
+++ b/Assets/Resources/Data/Maps/Mission/Spooky WavesMap.txt
@@ -2463,7 +2463,6 @@ class Main
     RespawnOnWave = true;
     GradualSpawn = true;
     GradualSpawnTooltip = "Spawn new titans gradually over time. Helpful for reducing lag.";
-    PumpkinHookable = true;
     _currentWave = 0;
     _hasSpawned = false;
     _jumpscare = false;
@@ -2529,12 +2528,7 @@ class Main
             {
                 name += "d";
             }
-            collisionMode = "None,Projectiles";
-            if (self.PumpkinHookable)
-            {
-                collisionMode = "Physical,Projectiles";
-            }
-            jack = Map.CreateMapObjectRaw("Scene,"+name+",0,0,1,0,1,0,PumpkinHead,"+trs+","+collisionMode+",Default,Default|255/255/255/255");
+            jack = Map.CreateMapObjectRaw("Scene,"+name+",0,0,1,0,1,0,PumpkinHead,"+trs+",None,Entities,Default,Default|255/255/255/255");
             jack.Parent = head;
             jack.Forward = head.Forward;
 
@@ -2552,7 +2546,7 @@ class Main
         scale = "" + sz.X + "," + sz.Y + "," + sz.Z;
         trs = pos + "," + rot + "," + scale;
         Game.Print("Spawning object: " + object + " at " + trs);
-        return Map.CreateMapObjectRaw("Scene,"+object+",0,0,1,0,1,0,"+name+","+trs+",Physical,Projectiles,Default,Default|255/255/255/255");
+        return Map.CreateMapObjectRaw("Scene,"+object+",0,0,1,0,1,0,"+name+","+trs+",None,Entities,Default,Default|255/255/255/255");
     }
 
 

--- a/Assets/Resources/UI/Prefabs/InGame/TopLeftHUD.prefab
+++ b/Assets/Resources/UI/Prefabs/InGame/TopLeftHUD.prefab
@@ -198,7 +198,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 800, y: 0}
+  m_SizeDelta: {x: 800, y: 10}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &11498114
 MonoBehaviour:
@@ -219,10 +219,10 @@ MonoBehaviour:
     m_Bottom: 10
   m_ChildAlignment: 6
   m_Spacing: 0
-  m_ChildForceExpandWidth: 1
-  m_ChildForceExpandHeight: 1
-  m_ChildControlWidth: 1
-  m_ChildControlHeight: 1
+  m_ChildForceExpandWidth: 0
+  m_ChildForceExpandHeight: 0
+  m_ChildControlWidth: 0
+  m_ChildControlHeight: 0
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
   m_ReverseArrangement: 0
@@ -233,7 +233,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 198122}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
   m_Name: 

--- a/Assets/Resources/UI/Prefabs/InGame/TopLeftHUD.prefab
+++ b/Assets/Resources/UI/Prefabs/InGame/TopLeftHUD.prefab
@@ -198,7 +198,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 800, y: 10}
+  m_SizeDelta: {x: 800, y: 0}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &11498114
 MonoBehaviour:
@@ -219,10 +219,10 @@ MonoBehaviour:
     m_Bottom: 10
   m_ChildAlignment: 6
   m_Spacing: 0
-  m_ChildForceExpandWidth: 0
-  m_ChildForceExpandHeight: 0
-  m_ChildControlWidth: 0
-  m_ChildControlHeight: 0
+  m_ChildForceExpandWidth: 1
+  m_ChildForceExpandHeight: 1
+  m_ChildControlWidth: 1
+  m_ChildControlHeight: 1
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
   m_ReverseArrangement: 0
@@ -233,7 +233,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 198122}
-  m_Enabled: 0
+  m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
   m_Name: 

--- a/Assets/Scripts/Characters/BaseCharacter.cs
+++ b/Assets/Scripts/Characters/BaseCharacter.cs
@@ -62,11 +62,11 @@ namespace Characters
         protected virtual float GroundDistance => 0.3f;
 
         // Visuals
-        private Outline _outline = null;
+        protected Outline OutlineComponent = null;
 
         public void Reveal(float startDelay, float activeTime)
         {
-            if (_outline == null)
+            if (OutlineComponent == null)
             {
                 StartCoroutine(RevealAndRemove(startDelay, activeTime));
             }
@@ -84,43 +84,43 @@ namespace Characters
 
         public void AddOutlineWithColor(Color color, Outline.Mode mode)
         {
-            if (_outline != null)
+            if (OutlineComponent != null)
             {
-                _outline.OutlineMode = mode;
-                _outline.OutlineColor = color;
-                _outline.enabled = true;
+                OutlineComponent.OutlineMode = mode;
+                OutlineComponent.OutlineColor = color;
+                OutlineComponent.enabled = true;
             }
         }
 
         public void ChangeOutlineColor(Color color)
         {
-            if (_outline != null)
+            if (OutlineComponent != null)
             {
-                _outline.OutlineColor = color;
+                OutlineComponent.OutlineColor = color;
             }
         }
 
         public void ChangeOutlineMode(Outline.Mode mode)
         {
-            if (_outline != null)
+            if (OutlineComponent != null)
             {
-                _outline.OutlineMode = mode;
+                OutlineComponent.OutlineMode = mode;
             }
         }
 
         public void ChangeOutlineWidth(float width)
         {
-            if (_outline != null)
+            if (OutlineComponent != null)
             {
-                _outline.OutlineWidth = width;
+                OutlineComponent.OutlineWidth = width;
             }
         }
 
         public void RemoveOutline()
         {
-            if (_outline != null)
+            if (OutlineComponent != null)
             {
-                _outline.enabled = false;
+                OutlineComponent.enabled = false;
             }
         }
 
@@ -573,8 +573,8 @@ namespace Characters
         {
 
             MinimapHandler.CreateMinimapIcon(this);
-            _outline = gameObject.AddComponent<Outline>();
-            _outline.enabled = false;
+            OutlineComponent = gameObject.AddComponent<Outline>();
+            OutlineComponent.enabled = false;
             StartCoroutine(WaitAndNotifySpawn());
         }
 

--- a/Assets/Scripts/Characters/BaseCharacter.cs
+++ b/Assets/Scripts/Characters/BaseCharacter.cs
@@ -66,10 +66,7 @@ namespace Characters
 
         public void Reveal(float startDelay, float activeTime)
         {
-            if (OutlineComponent == null)
-            {
-                StartCoroutine(RevealAndRemove(startDelay, activeTime));
-            }
+            StartCoroutine(RevealAndRemove(startDelay, activeTime));
         }
 
         public void AddOutline()

--- a/Assets/Scripts/Characters/Human/Hook.cs
+++ b/Assets/Scripts/Characters/Human/Hook.cs
@@ -107,6 +107,15 @@ namespace Characters
             _endSprite.SetActive(false);
         }
 
+        public void SetHookStateLocal(int state)
+        {
+            if (State == HookState.Disabled)
+                return;
+            State = (HookState)state;
+            _currentLiveTime = 0f;
+            _endSprite.SetActive(false);
+        }
+
         public void OnSetHooking(Vector3 baseVelocity, Vector3 relativeVelocity, PhotonMessageInfo info)
         {
             if (info.Sender != _owner.Cache.PhotonView.Owner)

--- a/Assets/Scripts/Characters/Human/HookUseable.cs
+++ b/Assets/Scripts/Characters/Human/HookUseable.cs
@@ -85,6 +85,12 @@ namespace Characters
             _activeHook = null;
         }
 
+        public void LocalClearAllHooks()
+        {
+            foreach (var hook in Hooks)
+                hook.SetHookStateLocal((int)HookState.DisablingHooked);
+        }
+
         protected override void Activate()
         {
             StartHook();

--- a/Assets/Scripts/Characters/Human/Human.cs
+++ b/Assets/Scripts/Characters/Human/Human.cs
@@ -957,9 +957,6 @@ namespace Characters
         {
             FinishSetup = false;
             Setup.Copy(settings);
-            HookLeft.DisableAnyHook();
-            HookRight.DisableAnyHook();
-
             if (IsMine())
             {
                 Cache.PhotonView.RPC("SetupRPC", RpcTarget.All, Setup.CustomSet.SerializeToJsonString(), (int)Setup.Weapon);
@@ -968,6 +965,7 @@ namespace Characters
             }
             ((InGameMenu)UIManager.CurrentMenu).HUDBottomHandler.SetBottomHUD(this);
         }
+
 
         protected override void Awake()
         {
@@ -2450,6 +2448,12 @@ namespace Characters
                 Stats.UpdateStats();
             }
             bool isGun = humanWeapon == (int)HumanWeapon.AHSS || humanWeapon == (int)HumanWeapon.APG;
+
+            if (HookLeft != null)
+                HookLeft.LocalClearAllHooks();
+            if (HookRight != null)
+                HookRight.LocalClearAllHooks();
+
             HookLeft = new HookUseable(this, true, isGun);
             HookRight = new HookUseable(this, false, isGun);
             bool male = Setup.CustomSet.Sex.Value == (int)HumanSex.Male;
@@ -2470,6 +2474,10 @@ namespace Characters
                 SetSpecial(SettingsManager.InGameCharacterSettings.Special.Value);
             }
             FinishSetup = true;
+            // ignore if name contains char_eyes, char_face, char_glasses
+            List<string> namesToIgnore = new List<string> { "char_eyes", "char_face", "char_glasses" };
+            
+            this.OutlineComponent.RefreshRenderers(namesToIgnore);
             CustomAnimationSpeed();
         }
 

--- a/Assets/Scripts/CustomLogic/Builtin/CustomLogicCharacterBuiltin.cs
+++ b/Assets/Scripts/CustomLogic/Builtin/CustomLogicCharacterBuiltin.cs
@@ -138,6 +138,8 @@ namespace CustomLogic
                 return Character.Guild;
             if (name == "IsMainCharacter")
                 return Character.IsMainCharacter();
+            if (name == "Transform")
+                return new CustomLogicTransformBuiltin(Character.Cache.Transform);
             if (name == "Position")
                 return new CustomLogicVector3Builtin(Character.Cache.Transform.position);
             if (name == "Rotation")

--- a/Assets/Scripts/CustomLogic/Builtin/CustomLogicTransformBuiltin.cs
+++ b/Assets/Scripts/CustomLogic/Builtin/CustomLogicTransformBuiltin.cs
@@ -119,6 +119,15 @@ namespace CustomLogic
                 Value.LookAt(target.Value);
                 return null;
             }
+            if (methodName == "SetRenderersEnabled")
+            {
+                bool enabled = (bool)parameters[0];
+                foreach (var renderer in Value.GetComponentsInChildren<Renderer>())
+                    renderer.enabled = enabled;
+
+                return null;
+            }
+
             return base.CallMethod(methodName, parameters);
         }
 

--- a/Assets/Scripts/UI/InGameMenu/TopLeftHUD.cs
+++ b/Assets/Scripts/UI/InGameMenu/TopLeftHUD.cs
@@ -35,6 +35,7 @@ namespace UI
             // set canvas pivot
             var rect = telemetryCanvas.GetComponent<RectTransform>();
             rect.pivot = ElementFactory.GetAnchorVector(TextAnchor.UpperLeft);
+            rect.sizeDelta = new Vector2(400, 60f);
 
             kdrCanvas = new GameObject();
             kdrCanvas.name = "KDR";
@@ -43,6 +44,7 @@ namespace UI
             // set canvas pivot
             rect = kdrCanvas.GetComponent<RectTransform>();
             rect.pivot = ElementFactory.GetAnchorVector(TextAnchor.UpperLeft);
+            rect.sizeDelta = new Vector2(500, 700f);
 
             telemetryCanvas.transform.SetParent(panel.transform);
             kdrCanvas.transform.SetParent(panel.transform);
@@ -71,7 +73,7 @@ namespace UI
 
         public void ApplySettings()
         {
-            var rect = kdrAndLabel.GetComponent<RectTransform>();
+            /*var rect = kdrAndLabel.GetComponent<RectTransform>();
 
             float verticaloffset = 0f;
             if (SettingsManager.GraphicsSettings.ShowFPS.Value || SettingsManager.UISettings.ShowPing.Value)
@@ -80,7 +82,7 @@ namespace UI
                 verticaloffset += 30;
 
             // Set the offset for the KDR panel
-            rect.anchoredPosition = new Vector2(0, -verticaloffset);
+            rect.anchoredPosition = new Vector2(0, -verticaloffset);*/
         }
     }
 }

--- a/Assets/Scripts/UI/InGameMenu/TopLeftHUD.cs
+++ b/Assets/Scripts/UI/InGameMenu/TopLeftHUD.cs
@@ -35,7 +35,6 @@ namespace UI
             // set canvas pivot
             var rect = telemetryCanvas.GetComponent<RectTransform>();
             rect.pivot = ElementFactory.GetAnchorVector(TextAnchor.UpperLeft);
-            rect.sizeDelta = new Vector2(400, 60f);
 
             kdrCanvas = new GameObject();
             kdrCanvas.name = "KDR";
@@ -44,7 +43,6 @@ namespace UI
             // set canvas pivot
             rect = kdrCanvas.GetComponent<RectTransform>();
             rect.pivot = ElementFactory.GetAnchorVector(TextAnchor.UpperLeft);
-            rect.sizeDelta = new Vector2(500, 700f);
 
             telemetryCanvas.transform.SetParent(panel.transform);
             kdrCanvas.transform.SetParent(panel.transform);
@@ -73,7 +71,7 @@ namespace UI
 
         public void ApplySettings()
         {
-            /*var rect = kdrAndLabel.GetComponent<RectTransform>();
+            var rect = kdrAndLabel.GetComponent<RectTransform>();
 
             float verticaloffset = 0f;
             if (SettingsManager.GraphicsSettings.ShowFPS.Value || SettingsManager.UISettings.ShowPing.Value)
@@ -82,7 +80,7 @@ namespace UI
                 verticaloffset += 30;
 
             // Set the offset for the KDR panel
-            rect.anchoredPosition = new Vector2(0, -verticaloffset);*/
+            rect.anchoredPosition = new Vector2(0, -verticaloffset);
         }
     }
 }

--- a/Assets/Scripts/UI/InGameMenu/TopLeftHUD.cs
+++ b/Assets/Scripts/UI/InGameMenu/TopLeftHUD.cs
@@ -31,12 +31,6 @@ namespace UI
             telemetryCanvas = new GameObject();
             telemetryCanvas.name = "Telemetry";
             var tcanvas = telemetryCanvas.AddComponent<Canvas>();
-            var tcanvasScaler = telemetryCanvas.AddComponent<CanvasScaler>();
-            tcanvasScaler.uiScaleMode = CanvasScaler.ScaleMode.ScaleWithScreenSize;
-            tcanvasScaler.referenceResolution = new Vector2(1920, 1080);
-            tcanvasScaler.screenMatchMode = CanvasScaler.ScreenMatchMode.MatchWidthOrHeight;
-            tcanvasScaler.matchWidthOrHeight = 0f;
-            tcanvasScaler.referencePixelsPerUnit = 100;
 
             // set canvas pivot
             var rect = telemetryCanvas.GetComponent<RectTransform>();
@@ -45,12 +39,6 @@ namespace UI
             kdrCanvas = new GameObject();
             kdrCanvas.name = "KDR";
             kdrCanvas.AddComponent<Canvas>();
-            var kdrcanvas = kdrCanvas.AddComponent<CanvasScaler>();
-            kdrcanvas.uiScaleMode = CanvasScaler.ScaleMode.ScaleWithScreenSize;
-            kdrcanvas.referenceResolution = new Vector2(1920, 1080);
-            kdrcanvas.screenMatchMode = CanvasScaler.ScreenMatchMode.MatchWidthOrHeight;
-            kdrcanvas.matchWidthOrHeight = 0f;
-            kdrcanvas.referencePixelsPerUnit = 100;
 
             // set canvas pivot
             rect = kdrCanvas.GetComponent<RectTransform>();


### PR DESCRIPTION
Remove lingering non-active hooks when switching character/weapon.
Fix partial outline bug.
Added support for filtering specific gameobjects out of the outline.
Fixed smell special.
Added method to get character transform in order to disable titan head when pumpkin head is on.
Reduced size of pumpkin head and added normal collisions.

