### PR TITLE
Fix wagon UI prompt displaying for other wagons while mounted

### DIFF
--- a/Assets/Resources/Data/Modes/BaseLogic.txt
+++ b/Assets/Resources/Data/Modes/BaseLogic.txt
@@ -2341,7 +2341,7 @@ component Wagon
             project = Vector3.Project(diff, self.MapObject.Forward);
             if (project.Magnitude > 3 * self.MapObject.Scale.Z && project.Normalized == self.MapObject.Forward)
             {
-                if (!self._inUse && !self._riding)
+                if (!self._inUse && !self._riding && !other.IsMounted)
                 {
                     UI.SetLabelForTime("MiddleCenter", "Press " + Input.GetKeyName("Interaction/Interact") + " to drive wagon.", 0.1);
                     self._collidingHuman = other;
@@ -2350,7 +2350,7 @@ component Wagon
             }
             elif (project.Magnitude > 4 * self.MapObject.Scale.Z && project.Normalized == self.MapObject.Forward * -1.0)
             {
-                if (!self._inUse && !self._riding && self.CanSupply)
+                if (!self._inUse && !self._riding && self.CanSupply && !other.IsMounted)
                 {
                     if (self.InfiniteSupply)
                     {
@@ -2372,7 +2372,7 @@ component Wagon
             }
             else
             {
-                if (!self._riding)
+                if (!self._riding && !other.IsMounted)
                 {
                     UI.SetLabelForTime("MiddleCenter", "Press " + Input.GetKeyName("Interaction/Interact") + " to ride wagon.", 0.1);
                     self._collidingHuman = other;


### PR DESCRIPTION
Resolved an issue where the wagon UI prompt incorrectly displayed while the player was already mounted.

![image](https://github.com/user-attachments/assets/c73f1174-9a8e-455f-9dee-6f8029c963bc)
