### PR TITLE
Fix OnGetHit in CustomLogicCollisionHandler

### DIFF
--- a/Assets/Scripts/CustomLogic/Component/CustomLogicCollisionHandler.cs
+++ b/Assets/Scripts/CustomLogic/Component/CustomLogicCollisionHandler.cs
@@ -26,7 +26,7 @@ namespace CustomLogic
             else if (character is BaseShifter)
                 builtin = new CustomLogicShifterBuiltin((BaseShifter)character);
             foreach (var classInstance in _classInstances)
-                classInstance.OnGetHit(builtin, name, damage, type, position);
+                classInstance.OnGetHit(builtin, name, damage, type, new CustomLogicVector3Builtin(position));
         }
 
         public void GetHooked(Human human, Vector3 position, bool left)


### PR DESCRIPTION
Convert the parameter `hitPosition` of `OnGetHit` to the `CustomLogicVector3Builtin` format so that it can be used correctly in custom logic.