### PR TITLE
Fix Ungrab Bugs

### DIFF
--- a/Assets/Scripts/Characters/Titan/BaseTitan.cs
+++ b/Assets/Scripts/Characters/Titan/BaseTitan.cs
@@ -385,7 +385,7 @@ namespace Characters
         {
             if (HoldHuman != null)
             {
-                HoldHuman.Cache.PhotonView.RPC("UngrabRPC", HoldHuman.Cache.PhotonView.Owner, new object[0]);
+                HoldHuman.Cache.PhotonView.RPC("UngrabRPC", RpcTarget.All, new object[0]);
                 HoldHuman.GrabHand = null;
                 HoldHuman = null;
             }

--- a/Assets/Scripts/Characters/Titan/BasicTitan.cs
+++ b/Assets/Scripts/Characters/Titan/BasicTitan.cs
@@ -903,8 +903,9 @@ namespace Characters
                     int damage = 100;
                     if (CustomDamageEnabled)
                         damage = CustomDamage;
-                    HoldHuman.GetHit(this, damage, "TitanEat", "");
-                    HoldHuman = null;
+                    var tempHoldHuman = HoldHuman;
+                    Ungrab();
+                    tempHoldHuman.GetHit(this, damage, "TitanEat", "");
                 }
             }
             if (!AI && HoldHuman && !HoldHuman.Dead && !HoldHumanLeft && (Input.anyKeyDown || State == TitanState.HumanThrow))


### PR DESCRIPTION
Fixed an issue, when the PT/Titan ungrabs a player, **other players still see that player as grabbed.** Any type of ungrab will now be visible to other players during blind attacks or escape skills. If the player still has any HP, they will be successfully ungrabbed.

escapeJeanFixedExample 

https://github.com/user-attachments/assets/fd564911-37ae-45f3-a21e-4949dd255a6a



hpFixExample  

https://github.com/user-attachments/assets/7ddd558d-2251-42d7-a0f1-b56476195271

                

BlindAttackExample         

https://github.com/user-attachments/assets/77d4928c-2b61-4742-a2c2-a3286ac46d57


