### PR TITLE
Added a way for CL to prevent/modify damage from `OnCharacterDamaged`

### DIFF
--- a/Assets/Scripts/Characters/BaseCharacter.cs
+++ b/Assets/Scripts/Characters/BaseCharacter.cs
@@ -38,6 +38,8 @@ namespace Characters
         public bool Dead;
         public bool CustomDamageEnabled;
         public int CustomDamage;
+        public bool CustomDamageReceivedEnabled;
+        public int CustomDamageReceived;
 
         // setup
         public BaseComponentCache Cache;
@@ -440,14 +442,20 @@ namespace Characters
         {
             if (Dead)
                 return;
+            var killer = Util.FindCharacterByViewId(viewId);
+            if (killer != null && name == "")
+                name = killer.Name;
+            if (CustomLogicManager.Evaluator != null)
+            {
+                CustomLogicManager.Evaluator.OnCharacterDamaged(this, killer, name, damage);
+                if (CustomDamageReceivedEnabled)
+                {
+                    damage = CustomDamageReceived;
+                    CustomDamageReceivedEnabled = false;
+                }
+            }
             if (damage == 0)
                 return;
-            if (name == "")
-            {
-                var killer = Util.FindCharacterByViewId(viewId);
-                if (killer != null)
-                    name = killer.Name;
-            }
             TakeDamage(damage);
             Cache.PhotonView.RPC("NotifyDamagedRPC", RpcTarget.All, new object[] { viewId, name, damage });
             if (CurrentHealth <= 0f)
@@ -463,6 +471,17 @@ namespace Characters
         {
             if (!Cache.PhotonView.IsMine || Dead)
                 return;
+            if (CustomLogicManager.Evaluator != null)
+            {
+                CustomLogicManager.Evaluator.OnCharacterDamaged(this, null, name, damage);
+                if (CustomDamageReceivedEnabled)
+                {
+                    damage = CustomDamageReceived;
+                    CustomDamageReceivedEnabled = false;
+                    if (damage == 0)
+                        return;
+                }
+            }
             TakeDamage(damage);
             Cache.PhotonView.RPC("NotifyDamagedRPC", RpcTarget.All, new object[] { -1, name, damage });
             if (CurrentHealth <= 0f)
@@ -525,9 +544,10 @@ namespace Characters
                 if (killer.IsMainCharacter() && CustomLogicManager.Evaluator != null && CustomLogicManager.Evaluator.DefaultAddKillScore)
                     _inGameManager.RegisterMainCharacterDamage(this, damage);
             }
-            if (CustomLogicManager.Evaluator == null)
-                return;
-            CustomLogicManager.Evaluator.OnCharacterDamaged(this, killer, name, damage);
+            if (CustomLogicManager.Evaluator != null && !Cache.PhotonView.IsMine)
+            {
+                CustomLogicManager.Evaluator.OnCharacterDamaged(this, killer, name, damage);
+            }
             if (SettingsManager.UISettings.GameFeed.Value)
             {
                 string keyword = " killed ";

--- a/Assets/Scripts/CustomLogic/Builtin/CustomLogicCharacterBuiltin.cs
+++ b/Assets/Scripts/CustomLogic/Builtin/CustomLogicCharacterBuiltin.cs
@@ -170,6 +170,10 @@ namespace CustomLogic
                 return Character.CustomDamageEnabled;
             if (name == "CustomDamage")
                 return Character.CustomDamage;
+            if (name == "CustomDamageReceivedEnabled")
+                return Character.CustomDamageReceivedEnabled;
+            if (name == "CustomDamageReceived")
+                return Character.CustomDamageReceived;
             if (name == "CurrentAnimation")
                 return Character.GetCurrentAnimation();
             if (name == "IsAI")
@@ -207,6 +211,10 @@ namespace CustomLogic
                 Character.CustomDamageEnabled = (bool)value;
             else if (name == "CustomDamage")
                 Character.CustomDamage = value.UnboxToInt();
+            else if (name == "CustomDamageReceivedEnabled")
+                Character.CustomDamageReceivedEnabled = (bool)value;
+            else if (name == "CustomDamageReceived")
+                Character.CustomDamageReceived = value.UnboxToInt();
             else if (name == "Name")
                 Character.Name = (string)value;
             else if (name == "Guild")


### PR DESCRIPTION
Creating this as an example of one way for the Custom Logic `OnCharacterDamaged` callback to prevent damage (for the character owner only).

Instead of only calling `OnCharacterDamaged` from `NotifyDamagedRPC`, we now only call it there for clients who are not the owner. For the character owner, `OnCharacterDamaged` is instead called before damage is even applied. This enables these callbacks to use the new `Character.CustomDamageReceivedEnabled` and `Character.CustomDamageReceived` fields (which mirror the `Character.CustomDamageEnabled` and `Character.CustomDamage` fields) to modify received damage before it is actually applied. If the damage is modified to 0, the hit is fully cancelled; character health is not modified and other clients are not even notified of the hit.

The ability to modify or cancel damage from the receiving end (rather than only from the attacking end) allows CL to modify damage using data that the attacker does not own (and therefore does not have realtime access to), such as whether or not the attacked player is invincible. Combined with `Character.CustomDamage`, it allows data owned by both clients to participate in damage calculations.