### PR TITLE
CL `Network.NetworkTime` fix and improvement

### DIFF
--- a/Assets/Scripts/CustomLogic/Builtin/CustomLogicNetworkBuiltin.cs
+++ b/Assets/Scripts/CustomLogic/Builtin/CustomLogicNetworkBuiltin.cs
@@ -35,7 +35,7 @@ namespace CustomLogic
             if (name == "GetTimestampDifference")
             {
                 // Handle the wrap around case photon timestamps have for the user since most will likely ignore it otherwise.
-                return Util.GetPhotonTimestampDifference(parameters[0].UnboxToDouble(), parameters[1].UnboxToDouble());
+                return Util.GetPhotonTimestampDifference(parameters[0].UnboxToFloat(), parameters[1].UnboxToFloat());
             }
             if (name == "KickPlayer")
             {
@@ -78,7 +78,7 @@ namespace CustomLogic
             if (name == "MyPlayer")
                 return new CustomLogicPlayerBuiltin(PhotonNetwork.LocalPlayer);
             if (name == "NetworkTime")
-                return PhotonNetwork.Time;
+                return (float)PhotonNetwork.Time;
             if (name == "Ping")
                 return PhotonNetwork.GetPing();
             return base.GetField(name);

--- a/Assets/Scripts/CustomLogic/Builtin/CustomLogicNetworkBuiltin.cs
+++ b/Assets/Scripts/CustomLogic/Builtin/CustomLogicNetworkBuiltin.cs
@@ -37,6 +37,11 @@ namespace CustomLogic
                 // Handle the wrap around case photon timestamps have for the user since most will likely ignore it otherwise.
                 return Util.GetPhotonTimestampDifference(parameters[0].UnboxToFloat(), parameters[1].UnboxToFloat());
             }
+            if (name == "GetMillisecondTimestampDifference")
+            {
+                // Handle the wrap around case photon timestamps have for the user since most will likely ignore it otherwise.
+                return Util.GetPhotonMillisecondTimestampDifference(parameters[0].UnboxToInt(), parameters[1].UnboxToInt());
+            }
             if (name == "KickPlayer")
             {
                 Photon.Realtime.Player player = null;
@@ -79,6 +84,8 @@ namespace CustomLogic
                 return new CustomLogicPlayerBuiltin(PhotonNetwork.LocalPlayer);
             if (name == "NetworkTime")
                 return (float)PhotonNetwork.Time;
+            if (name == "NetworkMillisecondTime")
+                return PhotonNetwork.ServerTimestamp;
             if (name == "Ping")
                 return PhotonNetwork.GetPing();
             return base.GetField(name);

--- a/Assets/Scripts/Utility/Util.cs
+++ b/Assets/Scripts/Utility/Util.cs
@@ -385,7 +385,7 @@ namespace Utility
                 && fileName.Length < 50;
         }
 
-        public static double GetPhotonTimestampDifference(double sentTime, double serverTime)
+        public static float GetPhotonTimestampDifference(float sentTime, float serverTime)
         {
             if (serverTime >= sentTime)
             {
@@ -393,7 +393,7 @@ namespace Utility
             }
 
             // Handle wrap-around
-            return (4294967.295 - sentTime) + serverTime;
+            return (4294967.295f - sentTime) + serverTime;
         }
     }
 }

--- a/Assets/Scripts/Utility/Util.cs
+++ b/Assets/Scripts/Utility/Util.cs
@@ -395,5 +395,21 @@ namespace Utility
             // Handle wrap-around
             return (4294967.295f - sentTime) + serverTime;
         }
+
+        public static int GetPhotonMillisecondTimestampDifference(int sentTime, int serverTime)
+        {
+            unchecked
+            {
+                uint uSentTime = (uint)sentTime;
+                uint uServerTime = (uint)serverTime;
+                if (uServerTime >= uSentTime)
+                {
+                    return (int)(uServerTime - uSentTime);
+                }
+
+                // Handle wrap-around
+                return (int)((uint.MaxValue - uSentTime) + uServerTime);
+            }
+        }
     }
 }


### PR DESCRIPTION
For a description of the reason for this, see the [thread on discord](https://discord.com/channels/681641241125060652/1326284543925162038).

PLEASE NOTE:
`PhotonNetwork.Time` is now inaccurate by up to around 250ms (please fact check that I'm not 100% sure) but, in exchange, can actually be used in CL instead of being useless. Of course, within realistic game lengths this should not be much of an issue.

Additionally, for long-running master clients, I am proposing `Network.NetworkMillisecondTime` and `Network.GetMillisecondTimestampDifference` as lossless alternatives.

An alternative option to everything in this PR would be to expand the CL language to handle `double` (or `uint`, or `long`) natively, at least for comparisons and literals, so you could write `if (Network.GetTimestampDifference(doubleTimestampA, doubleTimestampB) < 123.4)`.