### PR TITLE
Fixed HEX and HTML colors regex patterns

### DIFF
--- a/Assets/Scripts/Utility/Extensions/MiscExtensions.cs
+++ b/Assets/Scripts/Utility/Extensions/MiscExtensions.cs
@@ -13,8 +13,8 @@ using Utility;
 
 static class MiscExtensions
 {
-    static readonly string HexPattern = @"(\[)[\w]{6}(\])";
-    static readonly string ColorTagPattern = @"(<color=#)[\w]{6}(\>)";
+    static readonly string HexPattern = @"(\[)([A-Fa-f0-9]{3}|[A-Fa-f0-9]{6})(\])";
+    static readonly string ColorTagPattern = @"(<color=#)([A-Fa-f0-9]{3}|[A-Fa-f0-9]{6})(>)";
     static readonly string ColorEndPattern = @"(</color>)";
     static readonly string TagPattern = @"<\/?[^>]+>";
     static readonly string SizePattern = @"<\/?size.*?>";


### PR DESCRIPTION
- Updated regex for validating HEX & HTML color codes to support both 3-character and 6-character formats. Only 6-character format was supported before, however both are valid.
- Replaced `\w` part in pattern with `[A-Fa-f0-9]` since `\w` also uncludes underscore `_` which is not valid part of color code.

3-c HEX codes were not recognized during sanitization, resulting in incorrect truncation of both name and guild.

Also, having a 3-character HEX code in the middle _(having 3-c code in the beginning was fine)_ of your name _(for guild was fine)_, caused HTML tags in both name and guild to break. (attached a screenshot) Which is fixed now.
![{657D3EC3-7E02-468E-8EC9-10DB06BE4122}](https://github.com/user-attachments/assets/c3a34c1b-7f92-4e2a-8908-f0570bd29a77)
