### PR TITLE
Movement Changes - See Summary Below (important)

### DIFF
--- a/Assets/Scripts/Characters/Human/Hook.cs
+++ b/Assets/Scripts/Characters/Human/Hook.cs
@@ -19,6 +19,7 @@ namespace Characters
         public Transform HookParent;
         protected bool _hasHookParent;
         public LineRenderer _renderer;
+        public bool HasOffset = false;
         protected bool _left;
         protected Human _owner;
         protected int _id;
@@ -35,6 +36,19 @@ namespace Characters
         protected float _tiling;
         protected float _lastLength;
         protected float _maxLiveTime;
+
+
+        private bool _usingDeathTimer = false;
+        private Vector3 _lastGoodHookPoint = Vector3.zero;
+        private bool _firstDeathFrame = true;
+        private float _deathTimerOffset = 0.6f;
+
+        private void ResetState()
+        {
+            _usingDeathTimer = false;
+            _lastGoodHookPoint = Vector3.zero;
+            _firstDeathFrame = true;
+        }
 
         public static Hook CreateHook(Human owner, bool left, int id, float maxLiveTime, bool gun = false)
         {
@@ -160,6 +174,7 @@ namespace Characters
             _hasHookParent = false;
             if (transform != null)
             {
+                ResetState();
                 HookParent = transform;
                 _hookPosition = transform.InverseTransformPoint(position);
                 _hasHookParent = true;
@@ -289,6 +304,7 @@ namespace Characters
         {
             if (_owner.IsMine())
             {
+                HasOffset = false;
                 _hookPosition += _baseVelocity * Time.deltaTime * 50f + _relativeVelocity * Time.deltaTime;
                 Vector3 start = _nodes[_nodes.Count - 1];
                 if (_nodes.Count > 1)
@@ -347,7 +363,13 @@ namespace Characters
                             {
                                 MapObject mapObject = MapLoader.GoToMapObject[go];
                                 if (mapObject.ScriptObject.Static)
-                                    SetHooked(finalHit.point + new Vector3(0f, 0.1f, 0f));
+                                {
+                                    HasOffset = Vector3.Angle(Vector3.up, finalHit.normal) < 10f;
+                                    if (HasOffset)
+                                        SetHooked(finalHit.point + new Vector3(0f, 0.1f, 0f));  // Try and only add the offset if directly on a flat plane.
+                                    else
+                                        SetHooked(finalHit.point);
+                                }
                                 else if (mapObject.RuntimeCreated)
                                     SetHooked(finalHit.point, obj.transform);
                                 else
@@ -388,6 +410,7 @@ namespace Characters
 
         protected void FixedUpdate()
         {
+            _usingDeathTimer = false;
             if (State == HookState.Hooking)
                 FixedUpdateHooking();
             if (State == HookState.Hooking || State == HookState.Hooked)
@@ -398,6 +421,25 @@ namespace Characters
                 {
                     if (HookParent == null || (HookCharacter != null && HookCharacter.Dead && HookCharacter is Human))
                         SetHookState(HookState.DisablingHooked);
+
+                    // Hook timer for titan death
+                    if (HookParent != null && HookCharacter != null && HookCharacter is BasicTitan titan)
+                    {
+                        if (titan.Dead)
+                        {
+                            float timer = titan.DeathTimeElapsed();
+                            if (timer >= 0 && timer < _deathTimerOffset)
+                            {
+                                if (_firstDeathFrame)
+                                {
+                                    _lastGoodHookPoint = HookParent.TransformPoint(_hookPosition);
+                                    _lastWorldHookPosition = _lastGoodHookPoint;
+                                    _firstDeathFrame = false;
+                                }
+                                _usingDeathTimer = true;
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -407,7 +449,10 @@ namespace Characters
             if (_hasHookParent)
             {
                 if (HookParent != null)
-                    _lastWorldHookPosition = HookParent.TransformPoint(_hookPosition);
+                    if (_usingDeathTimer)
+                        _lastWorldHookPosition = _lastGoodHookPoint;
+                    else
+                        _lastWorldHookPosition = HookParent.TransformPoint(_hookPosition);
                 return _lastWorldHookPosition;
             }
             return _hookPosition;

--- a/Assets/Scripts/Characters/Human/HookUseable.cs
+++ b/Assets/Scripts/Characters/Human/HookUseable.cs
@@ -54,6 +54,13 @@ namespace Characters
             return Vector3.zero;
         }
 
+        public bool IsHookOffset()
+        {
+            if (_activeHook != null)
+                return _activeHook.HasOffset;
+            return false;
+        }
+
         public Transform GetHookParent()
         {
             return _activeHook.HookParent;

--- a/Assets/Scripts/Characters/Human/Human.cs
+++ b/Assets/Scripts/Characters/Human/Human.cs
@@ -1523,7 +1523,8 @@ namespace Characters
                     }
                     else if (State == HumanState.Slide)
                     {
-                        newVelocity = Cache.Rigidbody.velocity * 0.985f;
+                        if (!_wallSlide)
+                            newVelocity = Cache.Rigidbody.velocity * 0.985f;
                         if (_currentVelocity.magnitude < Stats.RunSpeed * 1.2f)
                         {
                             Idle();
@@ -2014,10 +2015,10 @@ namespace Characters
                     return;
             }
             float angle = Mathf.Abs(Vector3.Angle(velocity, _lastVelocity));
-            float speedMultiplier = Mathf.Max(1f - (angle * 1.5f * 0.01f), 0f);
+            float speedMultiplier = Mathf.Max(1f - (angle * 1.5f * 0.01f), 0f); // This is also likely different on titans as titans and mapobjects have different frictions.
             float speed = _lastVelocity.magnitude * speedMultiplier;
             Cache.Rigidbody.velocity = velocity.normalized * speed;
-            float speedDiff = _lastVelocity.magnitude - Cache.Rigidbody.velocity.magnitude;
+            float speedDiff = _lastVelocity.magnitude - Cache.Rigidbody.velocity.magnitude; // This is probably flawed on titans.
             if (SettingsManager.InGameCurrent.Misc.RealismMode.Value && speedDiff > RealismDeathVelocity)
             {
                 GetKilled("Impact");
@@ -2027,7 +2028,7 @@ namespace Characters
 
         protected void OnCollisionStay(Collision collision)
         {
-            if (!Grounded && Cache.Rigidbody.velocity.magnitude >= 15f && !Animation.IsPlaying(HumanAnimations.WallRun))
+            if (!Grounded && Cache.Rigidbody.velocity.magnitude >= 15f && !Animation.IsPlaying(HumanAnimations.WallRun) && collision.gameObject.layer != PhysicsLayer.MapObjectTitans)
             {
                 _wallSlide = true;
                 _wallSlideGround = collision.contacts[0].normal.normalized;
@@ -2147,7 +2148,16 @@ namespace Characters
             if (Grounded)
                 addSpeed = -0.01f;
             float newSpeed = _currentVelocity.magnitude + addSpeed;
-            Vector3 v = position - (Cache.Rigidbody.position - new Vector3(0, 0.020f, 0)); // 0.020F gives the player the original aottg1 clipping
+
+            Vector3 v = position - Cache.Rigidbody.position;
+            if (IsHookedLeft() && IsHookedRight())
+            {
+                if (HookLeft.IsHookOffset() && HookRight.IsHookOffset())
+                {
+                    v = position - (Cache.Rigidbody.position - new Vector3(0, 0.020f, 0)); // 0.020F gives the player the original aottg1 clipping required for bounce.
+                }
+            }
+           
             float reelAxis = GetReelAxis();
             if (reelAxis > 0f)
             {

--- a/Assets/Scripts/Characters/Titan/BasicTitan.cs
+++ b/Assets/Scripts/Characters/Titan/BasicTitan.cs
@@ -71,6 +71,15 @@ namespace Characters
             Animation.SetSpeed(BasicAnimations.CoverNape, 1.5f);
         }
 
+        public float DeathTimeElapsed()
+        {
+            if (Animation.IsPlaying(BasicAnimations.Die) || Animation.IsPlaying(BasicAnimations.DieBack) || Animation.IsPlaying(BasicAnimations.DieFront))
+            {
+                return Animation.GetCurrentNormalizedTime() * Animation.GetLength(_currentStateAnimation);
+            }
+            return -1f;
+        }
+
         public override bool IsGrabAttack()
         {
             return _currentAttack.StartsWith("AttackGrab");

--- a/Assets/Scripts/Map/MapLoader.cs
+++ b/Assets/Scripts/Map/MapLoader.cs
@@ -482,6 +482,12 @@ namespace Map
                     var renderer = filter.GetComponent<Renderer>();
                     if (renderer == null || renderer.sharedMaterials.Length > 1)
                         continue;
+                    if (filter?.sharedMesh == null)
+                    {
+                        DebugConsole.Log($"Map load error: object {mapObject.ScriptObject.Name} with missing mesh", true);
+                        Errors.Add("Failed to load static object with no MeshFilter or SharedMesh: " + mapObject.ScriptObject.Name);
+                        continue;
+                    }
                     string hash = filter.sharedMesh.GetHashCode().ToString();
                     hash += positionHash;
                     if (renderer.enabled)


### PR DESCRIPTION
Hook death timer added w/ 0.6s delay - this still looks a bit off but the results make the game more playable. We should probably view this as a stopgap still.

Removed wall slide on titans

Removed bounce mechanic offsets if the normal of the hook raycast was not vertical. This should prevent hook pull direction from being different from aottg1 except when needed for the bounce mechanic.

Removed wallslide friction - previously being alongside a wall did not slow your character down, this affects mostly racing but also allows for us to use wall slide more creatively in maps. (slide friction still exists and we can rework this later so that friction is properly applied based on slope and force going into the wall)

Fixed a bug that prevented maps from loading (the loading screen would softlock instead) if an asset marked as static did not have a shared mesh - now logs an error instead saying what object cannot be static.