### PR TITLE
Horseback combat

### DIFF
--- a/Assets/Resources/Data/Info/BuiltinMapInfo.json
+++ b/Assets/Resources/Data/Info/BuiltinMapInfo.json
@@ -111,6 +111,7 @@
 					"Name": "Outside The Walls",
 					"MiscSettings": {
 						"Horses": true,
+						"ActOnHorseback": false,
 						"AllowPlayerTitans": false,
 						"AllowShifters": false
 					}

--- a/Assets/Resources/Data/Info/BuiltinMapInfo.json
+++ b/Assets/Resources/Data/Info/BuiltinMapInfo.json
@@ -111,7 +111,7 @@
 					"Name": "Outside The Walls",
 					"MiscSettings": {
 						"Horses": true,
-						"ActOnHorseback": false,
+						"HorsebackCombat": false,
 						"AllowPlayerTitans": false,
 						"AllowShifters": false
 					}

--- a/Assets/Resources/Data/Modes/BaseLogic.txt
+++ b/Assets/Resources/Data/Modes/BaseLogic.txt
@@ -1839,7 +1839,7 @@ component SupplyStation
     function Init()
     {
         self._refillsLeft = self.MaxRefills;
-        self.MapObject.AddBoxCollider("Region", "Characters", Vector3(0,-2,0), Vector3(14,8,14));
+        self.MapObject.AddBoxCollider("Region", "Characters", Vector3(0,-2,0), Vector3(14,10,14));
     }
 
     function OnCollisionStay(other)

--- a/Assets/Resources/Spawnables/Prefabs/SupplySpawnable.prefab
+++ b/Assets/Resources/Spawnables/Prefabs/SupplySpawnable.prefab
@@ -94,7 +94,7 @@ BoxCollider:
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3
-  m_Size: {x: 3, y: 5, z: 2}
+  m_Size: {x: 5, y: 5, z: 5}
   m_Center: {x: 0, y: 1.5, z: 0}
 --- !u!1 &116124
 GameObject:

--- a/Assets/Scripts/Characters/Human/Horse/Horse.cs
+++ b/Assets/Scripts/Characters/Human/Horse/Horse.cs
@@ -216,7 +216,7 @@ namespace Characters
             base.LateUpdate();
             if (IsMine())
             {
-                if (_owner == null || _owner.Dead)
+                if (_owner == null || _owner.Dead || _owner.State != HumanState.Idle)
                     return;
                 if (Cache.Rigidbody.velocity.magnitude > 8f)
                 {

--- a/Assets/Scripts/Characters/Human/Horse/Horse.cs
+++ b/Assets/Scripts/Characters/Human/Horse/Horse.cs
@@ -216,26 +216,27 @@ namespace Characters
             base.LateUpdate();
             if (IsMine())
             {
-                if (_owner == null || _owner.Dead || _owner.State != HumanState.Idle)
+                if (_owner == null || _owner.Dead)
                     return;
+                bool humanActing = _owner.State != HumanState.Idle;
                 if (Cache.Rigidbody.velocity.magnitude > 8f)
                 {
                     CrossFadeIfNotPlaying(HorseAnimations.Run, 0.1f);
-                    if (_owner.MountState == HumanMountState.Horse)
+                    if (_owner.MountState == HumanMountState.Horse && !humanActing)
                         _owner.CrossFadeIfNotPlaying(HumanAnimations.HorseRun, 0.1f);
                     _idleTimeLeft = 0f;
                 }
                 else if (Cache.Rigidbody.velocity.magnitude > 1f)
                 {
                     CrossFadeIfNotPlaying(HorseAnimations.Walk, 0.1f);
-                    if (_owner.MountState == HumanMountState.Horse)
+                    if (_owner.MountState == HumanMountState.Horse && !humanActing)
                         _owner.CrossFadeIfNotPlaying(HumanAnimations.HorseIdle, 0.1f);
                     _idleTimeLeft = 0f;
                 }
                 else
                 {
                     UpdateIdle();
-                    if (_owner.MountState == HumanMountState.Horse)
+                    if (_owner.MountState == HumanMountState.Horse && !humanActing)
                         _owner.CrossFadeIfNotPlaying(HumanAnimations.HorseIdle, 0.1f);
                 }
             }

--- a/Assets/Scripts/Characters/Human/Human.cs
+++ b/Assets/Scripts/Characters/Human/Human.cs
@@ -62,6 +62,8 @@ namespace Characters
         public bool CanDodge = true;
         public bool IsInvincible = true;
         public float InvincibleTimeLeft;
+
+        public bool IsAttackableState;
         private object[] _lastMountMessage = null;
         private int _lastCarryRPCSender = -1;
         private float _grabIFrames = 0f;
@@ -1220,6 +1222,7 @@ namespace Characters
         {
             if (IsMine() && !Dead)
             {
+                IsAttackableState = MountState == HumanMountState.None || (MountState == HumanMountState.Horse && SettingsManager.InGameCurrent.Misc.ActOnHorseback.Value);
                 _stateTimeLeft -= Time.deltaTime;
                 _dashCooldownLeft -= Time.deltaTime;
                 _reloadCooldownLeft -= Time.deltaTime;
@@ -1266,7 +1269,8 @@ namespace Characters
                         Cache.Transform.rotation = Horse.Cache.Transform.rotation;
                     }
                 }
-                else if (State == HumanState.Attack)
+
+                if (State == HumanState.Attack)
                 {
                     if (Setup.Weapon == HumanWeapon.Blade)
                     {
@@ -1440,7 +1444,10 @@ namespace Characters
                 if (MountState == HumanMountState.Horse)
                 {
                     Cache.Rigidbody.velocity = Horse.Cache.Rigidbody.velocity;
-                    return;
+                    if (!IsAttackableState)
+                    {
+                        return;
+                    }
                 }
                 if (MountState == HumanMountState.MapObject)
                 {
@@ -1981,8 +1988,11 @@ namespace Characters
                 if (MountState == HumanMountState.None)
                 {
                     LateUpdateTilt();
-                    LateUpdateGun();
                     LateUpdateReelOut();
+                }
+                if (IsAttackableState)
+                {
+                    LateUpdateGun();
                 }
                 bool validState = State == HumanState.Idle || State == HumanState.Run || State == HumanState.Slide;
                 if (Grounded && validState && !_cameraFPS)

--- a/Assets/Scripts/Characters/Human/Human.cs
+++ b/Assets/Scripts/Characters/Human/Human.cs
@@ -1266,7 +1266,10 @@ namespace Characters
                     else
                     {
                         Cache.Transform.position = Horse.Cache.Transform.position + Vector3.up * 1.95f;
-                        Cache.Transform.rotation = Horse.Cache.Transform.rotation;
+                        if (!IsAttackableState || (_state != HumanState.Attack && _state != HumanState.SpecialAttack && _state != HumanState.SpecialAction))
+                        {
+                            Cache.Transform.rotation = Horse.Cache.Transform.rotation;
+                        }
                     }
                 }
 
@@ -1275,6 +1278,24 @@ namespace Characters
                     if (Setup.Weapon == HumanWeapon.Blade)
                     {
                         var bladeWeapon = (BladeWeapon)Weapon;
+                        if (MountState == HumanMountState.Horse && IsAttackableState)
+                        {
+                            // This allows bladers to attack enemies on a different plane
+                            var target = GetAimPoint();
+                            var start = Cache.Transform.position + Cache.Transform.up * 0.8f;
+                            var direction = (target - start).normalized;
+                            var forward = Cache.Transform.forward;
+                            float maxAngle = 60f;
+                            float angle = Vector3.Angle(forward, direction);
+
+                            if (angle > maxAngle)
+                            {
+                                // Rotate the direction vector to the legal range
+                                Quaternion rotation = Quaternion.AngleAxis(maxAngle * Mathf.Sign(Vector3.SignedAngle(forward, direction, Vector3.up)), Vector3.up);
+                                direction = rotation * forward;
+                            }
+                            Cache.Transform.rotation = Quaternion.LookRotation(direction);
+                        }
                         if (!bladeWeapon.IsActive)
                             _attackButtonRelease = true;
                         if (!_attackRelease)

--- a/Assets/Scripts/Characters/Human/Human.cs
+++ b/Assets/Scripts/Characters/Human/Human.cs
@@ -938,7 +938,7 @@ namespace Characters
 
         public bool CanEmote()
         {
-            return !Dead && State != HumanState.Grab && CarryState != HumanCarryState.Carry && State != HumanState.AirDodge && State != HumanState.EmoteAction && State != HumanState.SpecialAttack && MountState == HumanMountState.None
+            return !Dead && State != HumanState.Grab && CarryState != HumanCarryState.Carry && State != HumanState.AirDodge && State != HumanState.EmoteAction && State != HumanState.SpecialAttack && IsAttackableState
                 && State != HumanState.Stun;
         }
 

--- a/Assets/Scripts/Characters/Human/Human.cs
+++ b/Assets/Scripts/Characters/Human/Human.cs
@@ -63,7 +63,7 @@ namespace Characters
         public bool IsInvincible = true;
         public float InvincibleTimeLeft;
         
-        public bool ActOnHorseback = false;
+        public bool HorsebackCombat = false;
         public bool IsAttackableState;
         public bool IsRefillable;
         private object[] _lastMountMessage = null;
@@ -1224,9 +1224,9 @@ namespace Characters
         {
             if (IsMine() && !Dead)
             {
-                ActOnHorseback = MountState == HumanMountState.Horse && SettingsManager.InGameCurrent.Misc.ActOnHorseback.Value;
-                IsAttackableState = MountState == HumanMountState.None || ActOnHorseback;
-                IsRefillable = State == HumanState.Idle && (Grounded || ActOnHorseback);
+                HorsebackCombat = MountState == HumanMountState.Horse && SettingsManager.InGameCurrent.Misc.HorsebackCombat.Value;
+                IsAttackableState = MountState == HumanMountState.None || HorsebackCombat;
+                IsRefillable = State == HumanState.Idle && (Grounded || HorsebackCombat);
                 _stateTimeLeft -= Time.deltaTime;
                 _dashCooldownLeft -= Time.deltaTime;
                 _reloadCooldownLeft -= Time.deltaTime;

--- a/Assets/Scripts/Characters/Human/Human.cs
+++ b/Assets/Scripts/Characters/Human/Human.cs
@@ -62,8 +62,10 @@ namespace Characters
         public bool CanDodge = true;
         public bool IsInvincible = true;
         public float InvincibleTimeLeft;
-
+        
+        public bool ActOnHorseback = false;
         public bool IsAttackableState;
+        public bool IsRefillable;
         private object[] _lastMountMessage = null;
         private int _lastCarryRPCSender = -1;
         private float _grabIFrames = 0f;
@@ -834,7 +836,7 @@ namespace Characters
 
         public bool Refill()
         {
-            if (!Grounded || State != HumanState.Idle)
+            if (!IsRefillable)
                 return false;
             State = HumanState.Refill;
             if (Special is SupplySpecial)
@@ -849,7 +851,7 @@ namespace Characters
         }
         public bool SupplySpawnableRefill()
         {
-            if (!Grounded || State != HumanState.Idle)
+            if (!IsRefillable)
                 return false;
             State = HumanState.Refill;
             ToggleSparks(false);
@@ -1222,7 +1224,9 @@ namespace Characters
         {
             if (IsMine() && !Dead)
             {
-                IsAttackableState = MountState == HumanMountState.None || (MountState == HumanMountState.Horse && SettingsManager.InGameCurrent.Misc.ActOnHorseback.Value);
+                ActOnHorseback = MountState == HumanMountState.Horse && SettingsManager.InGameCurrent.Misc.ActOnHorseback.Value;
+                IsAttackableState = MountState == HumanMountState.None || ActOnHorseback;
+                IsRefillable = State == HumanState.Idle && (Grounded || ActOnHorseback);
                 _stateTimeLeft -= Time.deltaTime;
                 _dashCooldownLeft -= Time.deltaTime;
                 _reloadCooldownLeft -= Time.deltaTime;

--- a/Assets/Scripts/Characters/Human/Human.cs
+++ b/Assets/Scripts/Characters/Human/Human.cs
@@ -3053,7 +3053,7 @@ namespace Characters
 
         public void StartBladeSwing()
         {
-            if (!Grounded && (HookLeft.IsHooked() || HookRight.IsHooked()))
+            if (!Grounded && (HookLeft.IsHooked() || HookRight.IsHooked() || MountState == HumanMountState.Horse))
             {
                 if (SettingsManager.InputSettings.General.Left.GetKey())
                     AttackAnimation = (UnityEngine.Random.Range(0, 100) >= 50) ? HumanAnimations.Attack1HookL1 : HumanAnimations.Attack1HookL2;

--- a/Assets/Scripts/Characters/Human/Human.cs
+++ b/Assets/Scripts/Characters/Human/Human.cs
@@ -1288,8 +1288,8 @@ namespace Characters
                             var target = GetAimPoint();
                             var start = Cache.Transform.position + Cache.Transform.up * 0.8f;
                             var direction = (target - start).normalized;
-                            var forward = Cache.Transform.forward;
-                            float maxAngle = 60f;
+                            var forward = Horse.Cache.Transform.forward;
+                            float maxAngle = 70f;
                             float angle = Vector3.Angle(forward, direction);
 
                             if (angle > maxAngle)
@@ -1298,7 +1298,7 @@ namespace Characters
                                 Quaternion rotation = Quaternion.AngleAxis(maxAngle * Mathf.Sign(Vector3.SignedAngle(forward, direction, Vector3.up)), Vector3.up);
                                 direction = rotation * forward;
                             }
-                            Cache.Transform.rotation = Quaternion.LookRotation(direction);
+                            Cache.Transform.rotation = Quaternion.Lerp(Cache.Transform.rotation, Quaternion.LookRotation(direction), Time.deltaTime * 10.0f);
                         }
                         if (!bladeWeapon.IsActive)
                             _attackButtonRelease = true;
@@ -1505,7 +1505,10 @@ namespace Characters
                 {
                     rotationSpeed = 10f;
                 }
-                Cache.Transform.rotation = Quaternion.Lerp(Cache.Transform.rotation, _targetRotation, Time.deltaTime * rotationSpeed);
+                if (MountState != HumanMountState.Horse)
+                {
+                    Cache.Transform.rotation = Quaternion.Lerp(Cache.Transform.rotation, _targetRotation, Time.deltaTime * rotationSpeed);
+                }
                 bool pivotLeft = FixedUpdateLaunch(true);
                 bool pivotRight = FixedUpdateLaunch(false);
                 bool pivot = pivotLeft || pivotRight;

--- a/Assets/Scripts/Characters/Human/Specials/DownStrikeSpecial.cs
+++ b/Assets/Scripts/Characters/Human/Specials/DownStrikeSpecial.cs
@@ -15,6 +15,10 @@ namespace Characters
 
         protected override void Activate()
         {
+            if (_human.MountState == HumanMountState.Horse && _human.IsAttackableState)
+            {
+                _human.Unmount(false);
+            }
             _needActivate = true;
             _human.HookLeft.DisableAnyHook();
             _human.HookRight.DisableAnyHook();

--- a/Assets/Scripts/Characters/Human/Specials/Spin3Special.cs
+++ b/Assets/Scripts/Characters/Human/Specials/Spin3Special.cs
@@ -23,6 +23,10 @@ namespace Characters
 
         protected override void Activate()
         {
+            if (_human.MountState == HumanMountState.Horse && _human.IsAttackableState)
+            {
+                _human.Unmount(true);
+            }
             _stage = 0;
             _human.HookLeft.DisableAnyHook();
             _human.HookRight.DisableAnyHook();

--- a/Assets/Scripts/Characters/Human/Specials/SupplySpecial.cs
+++ b/Assets/Scripts/Characters/Human/Specials/SupplySpecial.cs
@@ -9,6 +9,7 @@ namespace Characters
     class SupplySpecial : BaseEmoteSpecial
     {
         protected override float ActiveTime => 0.5f;
+        protected override bool GroundedOnly => false;
 
         public SupplySpecial(BaseCharacter owner): base(owner)
         {
@@ -22,6 +23,11 @@ namespace Characters
         protected override void Activate()
         {
             _human.EmoteAnimation(HumanAnimations.EmoteWave);
+        }
+
+        public override bool CanUse()
+        {
+            return base.CanUse() && (_human.ActOnHorseback || _human.Grounded);
         }
 
         protected override void Deactivate()

--- a/Assets/Scripts/Characters/Human/Specials/SupplySpecial.cs
+++ b/Assets/Scripts/Characters/Human/Specials/SupplySpecial.cs
@@ -27,7 +27,7 @@ namespace Characters
 
         public override bool CanUse()
         {
-            return base.CanUse() && (_human.ActOnHorseback || _human.Grounded);
+            return base.CanUse() && (_human.HorsebackCombat || _human.Grounded);
         }
 
         protected override void Deactivate()

--- a/Assets/Scripts/Characters/Human/Specials/SwitchbackSpecial.cs
+++ b/Assets/Scripts/Characters/Human/Specials/SwitchbackSpecial.cs
@@ -29,6 +29,22 @@ namespace Characters
             return false;
         }
 
+        public override void SetInput(bool key)
+        {
+            if (key && CanUse() && !IsActive)
+            {
+                var human = ((Human)_owner);
+                if (human.MountState == HumanMountState.Horse && human.IsAttackableState)
+                {
+                    human.Unmount(false);
+                }
+                IsActive = true;
+                _activeTimeLeft = GetActiveTime();
+                Activate();
+                OnUse();
+            }
+        }
+
         protected override void Activate()
         {
             ((Human)_owner).StartGrabImmunity(GrabIFrameDuration);

--- a/Assets/Scripts/Controllers/HumanPlayerController.cs
+++ b/Assets/Scripts/Controllers/HumanPlayerController.cs
@@ -352,7 +352,7 @@ namespace Controllers
             }
             else if (_human.MountState == HumanMountState.Horse)
             {
-                if (_humanInput.HorseMount.GetKeyDown())
+                if (_humanInput.HorseMount.GetKeyDown() && _human.State == HumanState.Idle)
                     _human.Unmount(false);
                 else if (_humanInput.HorseJump.GetKeyDown())
                     _human.Horse.Jump();

--- a/Assets/Scripts/Controllers/HumanPlayerController.cs
+++ b/Assets/Scripts/Controllers/HumanPlayerController.cs
@@ -277,7 +277,6 @@ namespace Controllers
                 if (_human.Weapon is AmmoWeapon && ((AmmoWeapon)_human.Weapon).RoundLeft == 0 &&
                     !(_human.Weapon is ThunderspearWeapon && ((ThunderspearWeapon)_human.Weapon).HasActiveProjectile()))
                 {
-                    Debug.Log("Reload state " + _human.State);
                     if (attackInput.GetKeyDown() && _human.State == HumanState.Idle)
                         _human.Reload();
                 }

--- a/Assets/Scripts/Controllers/HumanPlayerController.cs
+++ b/Assets/Scripts/Controllers/HumanPlayerController.cs
@@ -263,7 +263,7 @@ namespace Controllers
             UpdateHookInput(inMenu);
             UpdateReelInput(inMenu);
             UpdateDashInput(inMenu);
-            bool canWeapon = _human.MountState == HumanMountState.None && !_illegalWeaponStates.Contains(_human.State) && !inMenu && !_human.Dead;
+            bool canWeapon =  _human.IsAttackableState && !_illegalWeaponStates.Contains(_human.State) && !inMenu && !_human.Dead;
             var attackInput = _humanInput.AttackDefault;
             var specialInput = _humanInput.AttackSpecial;
             if (_human.Weapon is ThunderspearWeapon && SettingsManager.InputSettings.Human.SwapTSAttackSpecial.Value)
@@ -277,6 +277,7 @@ namespace Controllers
                 if (_human.Weapon is AmmoWeapon && ((AmmoWeapon)_human.Weapon).RoundLeft == 0 &&
                     !(_human.Weapon is ThunderspearWeapon && ((ThunderspearWeapon)_human.Weapon).HasActiveProjectile()))
                 {
+                    Debug.Log("Reload state " + _human.State);
                     if (attackInput.GetKeyDown() && _human.State == HumanState.Idle)
                         _human.Reload();
                 }
@@ -304,10 +305,10 @@ namespace Controllers
                 _human.Weapon.SetInput(false);
             if (_human.Special != null)
             {
-                bool canSpecial = _human.MountState == HumanMountState.None &&
+                bool canSpecial = _human.IsAttackableState &&
                     (_human.Special is EscapeSpecial || _human.Special is ShifterTransformSpecial || _human.State != HumanState.Grab) && _human.CarryState != HumanCarryState.Carry
                     && _human.State != HumanState.EmoteAction && _human.State != HumanState.Attack && _human.State != HumanState.SpecialAttack && !inMenu && !_human.Dead;
-                bool canSpecialHold = _human.Special is BaseHoldAttackSpecial && _human.MountState == HumanMountState.None && _human.State != HumanState.Grab && (_human.State != HumanState.Attack || _human.Special is StockSpecial) &&
+                bool canSpecialHold = _human.Special is BaseHoldAttackSpecial && _human.IsAttackableState && _human.State != HumanState.Grab && (_human.State != HumanState.Attack || _human.Special is StockSpecial) &&
                     _human.State != HumanState.EmoteAction && _human.State != HumanState.Grab && _human.CarryState != HumanCarryState.Carry && !inMenu && !_human.Dead;
                 if (canSpecial || canSpecialHold)
                 {
@@ -356,6 +357,12 @@ namespace Controllers
                     _human.Unmount(false);
                 else if (_humanInput.HorseJump.GetKeyDown())
                     _human.Horse.Jump();
+
+                if (_human.State == HumanState.Idle && _human.IsAttackableState)
+                {
+                    if (_humanInput.Reload.GetKeyDown())
+                        _human.Reload();
+                }
             }
         }
 

--- a/Assets/Scripts/Settings/InGame/InGameMiscSettings.cs
+++ b/Assets/Scripts/Settings/InGame/InGameMiscSettings.cs
@@ -20,7 +20,7 @@ namespace Settings
         public BoolSetting AllowShifters = new BoolSetting(false);
         public BoolSetting AllowVoteKicking = new BoolSetting(false);
         public BoolSetting Horses = new BoolSetting(false);
-        public BoolSetting ActOnHorseback = new BoolSetting(false);
+        public BoolSetting HorsebackCombat = new BoolSetting(false);
         public BoolSetting GunsAirReload = new BoolSetting(true);
         public BoolSetting AllowStock = new BoolSetting(true);
         public BoolSetting ClearKDROnRestart = new BoolSetting(true);

--- a/Assets/Scripts/Settings/InGame/InGameMiscSettings.cs
+++ b/Assets/Scripts/Settings/InGame/InGameMiscSettings.cs
@@ -20,6 +20,7 @@ namespace Settings
         public BoolSetting AllowShifters = new BoolSetting(false);
         public BoolSetting AllowVoteKicking = new BoolSetting(false);
         public BoolSetting Horses = new BoolSetting(false);
+        public BoolSetting ActOnHorseback = new BoolSetting(false);
         public BoolSetting GunsAirReload = new BoolSetting(true);
         public BoolSetting AllowStock = new BoolSetting(true);
         public BoolSetting ClearKDROnRestart = new BoolSetting(true);

--- a/Assets/Scripts/Spawnables/SupplySpawnable.cs
+++ b/Assets/Scripts/Spawnables/SupplySpawnable.cs
@@ -7,9 +7,9 @@ namespace Spawnables
 {
     class SupplySpawnable: BaseSpawnable
     {
-        protected void OnCollisionStay(Collision collision)
+        protected void OnTriggerStay(Collider other)
         {
-            var go = collision.transform.root.gameObject;
+            var go = other.transform.root.gameObject;
             var human = go.GetComponent<Human>();
             if (human != null && human.IsMine() && human.NeedRefill(false))
                 human.SupplySpawnableRefill();

--- a/Assets/Scripts/UI/CreateGamePopup/CreateGameMiscPanel.cs
+++ b/Assets/Scripts/UI/CreateGamePopup/CreateGameMiscPanel.cs
@@ -26,6 +26,7 @@ namespace UI
             ElementFactory.CreateToggleSetting(DoublePanelLeft, style, settings.CustomPerks, UIManager.GetLocale(cat, sub, "CustomPerks"), UIManager.GetLocale(cat, sub, "CustomPerksTooltip"));
             ElementFactory.CreateToggleSetting(DoublePanelLeft, style, settings.RealismMode, UIManager.GetLocale(cat, sub, "RealismMode"), UIManager.GetLocale(cat, sub, "RealismModeTooltip"));
             ElementFactory.CreateToggleSetting(DoublePanelLeft, style, settings.Horses, UIManager.GetLocale(cat, sub, "Horses"));
+            ElementFactory.CreateToggleSetting(DoublePanelLeft, style, settings.ActOnHorseback, UIManager.GetLocale(cat, sub, "ActOnHorseback"));
             ElementFactory.CreateToggleSetting(DoublePanelLeft, style, settings.EndlessRespawnEnabled, UIManager.GetLocale(cat, sub, "EndlessRespawnEnabled"));
             ElementFactory.CreateInputSetting(DoublePanelLeft, style, settings.EndlessRespawnTime, UIManager.GetLocale(cat, sub, "EndlessRespawnTime"), elementWidth: inputWidth);
             ElementFactory.CreateInputSetting(DoublePanelLeft, style, settings.AllowSpawnTime, UIManager.GetLocale(cat, sub, "AllowSpawnTime"), UIManager.GetLocale(cat, sub, "AllowSpawnTimeTooltip"), elementWidth: inputWidth);

--- a/Assets/Scripts/UI/CreateGamePopup/CreateGameMiscPanel.cs
+++ b/Assets/Scripts/UI/CreateGamePopup/CreateGameMiscPanel.cs
@@ -26,7 +26,7 @@ namespace UI
             ElementFactory.CreateToggleSetting(DoublePanelLeft, style, settings.CustomPerks, UIManager.GetLocale(cat, sub, "CustomPerks"), UIManager.GetLocale(cat, sub, "CustomPerksTooltip"));
             ElementFactory.CreateToggleSetting(DoublePanelLeft, style, settings.RealismMode, UIManager.GetLocale(cat, sub, "RealismMode"), UIManager.GetLocale(cat, sub, "RealismModeTooltip"));
             ElementFactory.CreateToggleSetting(DoublePanelLeft, style, settings.Horses, UIManager.GetLocale(cat, sub, "Horses"));
-            ElementFactory.CreateToggleSetting(DoublePanelLeft, style, settings.ActOnHorseback, UIManager.GetLocale(cat, sub, "ActOnHorseback"));
+            ElementFactory.CreateToggleSetting(DoublePanelLeft, style, settings.HorsebackCombat, UIManager.GetLocale(cat, sub, "HorsebackCombat"));
             ElementFactory.CreateToggleSetting(DoublePanelLeft, style, settings.EndlessRespawnEnabled, UIManager.GetLocale(cat, sub, "EndlessRespawnEnabled"));
             ElementFactory.CreateInputSetting(DoublePanelLeft, style, settings.EndlessRespawnTime, UIManager.GetLocale(cat, sub, "EndlessRespawnTime"), elementWidth: inputWidth);
             ElementFactory.CreateInputSetting(DoublePanelLeft, style, settings.AllowSpawnTime, UIManager.GetLocale(cat, sub, "AllowSpawnTime"), UIManager.GetLocale(cat, sub, "AllowSpawnTimeTooltip"), elementWidth: inputWidth);

--- a/Assets/StreamingAssets/Languages/Chinese.json
+++ b/Assets/StreamingAssets/Languages/Chinese.json
@@ -159,7 +159,7 @@
     "Misc.HumanHealth": "人类生命值",
 		"Misc.ShifterHealth": "巨人之力生命值",
     "Misc.Horses": "马匹",
-    "Misc.HorsebackCombat": "马背上行动",
+    "Misc.HorsebackCombat": "马背上作战",
     "Misc.HorseSpeed": "马匹速度",
     "Misc.GunsAirReload": "AHSS/APG空中装填",
     "Misc.AllowStock": "允许地面绳索技术",

--- a/Assets/StreamingAssets/Languages/Chinese.json
+++ b/Assets/StreamingAssets/Languages/Chinese.json
@@ -159,6 +159,7 @@
     "Misc.HumanHealth": "人类生命值",
 		"Misc.ShifterHealth": "巨人之力生命值",
     "Misc.Horses": "马匹",
+    "Misc.ActOnHorseback": "马背上行动",
     "Misc.HorseSpeed": "马匹速度",
     "Misc.GunsAirReload": "AHSS/APG空中装填",
     "Misc.AllowStock": "允许地面绳索技术",

--- a/Assets/StreamingAssets/Languages/Chinese.json
+++ b/Assets/StreamingAssets/Languages/Chinese.json
@@ -159,7 +159,7 @@
     "Misc.HumanHealth": "人类生命值",
 		"Misc.ShifterHealth": "巨人之力生命值",
     "Misc.Horses": "马匹",
-    "Misc.ActOnHorseback": "马背上行动",
+    "Misc.HorsebackCombat": "马背上行动",
     "Misc.HorseSpeed": "马匹速度",
     "Misc.GunsAirReload": "AHSS/APG空中装填",
     "Misc.AllowStock": "允许地面绳索技术",

--- a/Assets/StreamingAssets/Languages/English.json
+++ b/Assets/StreamingAssets/Languages/English.json
@@ -168,7 +168,7 @@
 		"Misc.AllowShifterSpecials": "Allow shifter specials",
 		"Misc.AllowVoteKicking": "Allow vote kicking",
 		"Misc.Horses": "Horses",
-		"Misc.ActOnHorseback": "Act on horseback",
+		"Misc.HorsebackCombat": "Horseback combat",
 		"Misc.HorseSpeed": "Horse speed",
 		"Misc.GunsAirReload": "Guns air reload",
 		"Misc.AllowStock": "Allow stock",

--- a/Assets/StreamingAssets/Languages/English.json
+++ b/Assets/StreamingAssets/Languages/English.json
@@ -168,6 +168,7 @@
 		"Misc.AllowShifterSpecials": "Allow shifter specials",
 		"Misc.AllowVoteKicking": "Allow vote kicking",
 		"Misc.Horses": "Horses",
+		"Misc.ActOnHorseback": "Act on horseback",
 		"Misc.HorseSpeed": "Horse speed",
 		"Misc.GunsAirReload": "Guns air reload",
 		"Misc.AllowStock": "Allow stock",

--- a/Assets/StreamingAssets/Languages/Japanese.json
+++ b/Assets/StreamingAssets/Languages/Japanese.json
@@ -159,6 +159,7 @@
 		"Misc.ShifterHealth": "巨人化のＨＰ",
 		"Misc.AllowVoteKicking": "votekick を有効化",
 		"Misc.Horses": "馬",
+		"Misc.HorsebackCombat": "騎馬戦",
 		"Misc.HorseSpeed": "馬の速度",
 		"Misc.GunsAirReload": "AHSS空中リロード",
 		"Misc.AllowStock": "スライドを許可する",


### PR DESCRIPTION
Humans are allowed to attack on horseback. 
Discussion: https://discord.com/channels/681641241125060652/1348411234269007934

feature && test:
- [x] Checkbox on game pane wrt "HorsebackCombat" .
![image](https://github.com/user-attachments/assets/d410619e-c896-49a9-9d94-60075aaa3bc8)
- [x] blade and reload
- [x] ahss, reload and auto reload
- [x] apg, reload and auto reload
- [x] ts, reload and auto reload
- [x] potato special
- [x] dance special
- [x] distract special
- [x] smell special
- [x] supply special (ground and horseback only)
- [x] Request a larger triggle area for SpawnableSupply.prefab so that human can refill on horseback (3. 5. 2) ->(5,5,5). The original one is too small, even on the ground.  Further more, change OnCollisionStay to OnTrigglerStay (I think it was written wrong before because SupplySpawnable has a BoxTrigger)
- [x] Smoke bomp special
- [x] carry special
- [x] switchback special (dismount automatically)
- [x] confuse special
- [x] downstrike special (dismount automatically)
- [x] spin1 special
- [x] spin2 special
- [x] spin3 special (dismount automatically)
- [x] bladethrow special
- [x] erenshifter, annieshifter special
- [x]  AHSSTwinShot special
- [x] Stock Special  

Other：About string "HorsebackCombat", no translation yet, only English, Chinese and Japanese.