### PR TITLE
Fixed re-scaling of particles

### DIFF
--- a/Assets/Scripts/Characters/Titan/BaseTitan.cs
+++ b/Assets/Scripts/Characters/Titan/BaseTitan.cs
@@ -957,8 +957,8 @@ namespace Characters
             foreach (ParticleSystem system in GetComponentsInChildren<ParticleSystem>())
             {
                 var main = system.main;
-                main.startSizeMultiplier *= size;
-                main.startSpeedMultiplier *= size;
+                Util.ScaleParticleStartSize(main, size);
+                Util.ScaleParticleStartSpeed(main, size);
             }
         }
 

--- a/Assets/Scripts/Characters/Titan/BasicTitan.cs
+++ b/Assets/Scripts/Characters/Titan/BasicTitan.cs
@@ -95,8 +95,9 @@ namespace Characters
             base.SetSizeParticles(size);
             foreach (ParticleSystem system in new ParticleSystem[] { BasicCache.ForearmSmokeL, BasicCache.ForearmSmokeR })
             {
-                system.startSize *= size;
-                system.startSpeed *= size;
+                var main = system.main;
+                Util.ScaleParticleStartSize(main, size);
+                Util.ScaleParticleStartSpeed(main, size);
             }
             BasicCache.ForearmSmokeL.transform.localScale = Vector3.one * Size;
             BasicCache.ForearmSmokeR.transform.localScale = Vector3.one * Size;

--- a/Assets/Scripts/Effects/EffectSpawner.cs
+++ b/Assets/Scripts/Effects/EffectSpawner.cs
@@ -49,9 +49,9 @@ namespace Effects
                 return;
             foreach (ParticleSystem system in transform.GetComponentsInChildren<ParticleSystem>())
             {
-                var emission = system.main;
-                emission.startSpeedMultiplier *= scale;
-                emission.startSizeMultiplier *= scale;
+                var main = system.main;
+                Util.ScaleParticleStartSize(main, scale);
+                Util.ScaleParticleStartSpeed(main, scale);
             }
         }
     }

--- a/Assets/Scripts/Effects/ThunderspearExplodeEffect.cs
+++ b/Assets/Scripts/Effects/ThunderspearExplodeEffect.cs
@@ -5,6 +5,7 @@ using System.Collections;
 using Settings;
 using Photon.Realtime;
 using Projectiles;
+using Utility;
 
 namespace Effects
 {
@@ -26,7 +27,7 @@ namespace Effects
             else
             {
                 var main = particle.main;
-                main.startSizeMultiplier *= SizeMultiplier;
+                Util.ScaleParticleStartSize(main, SizeMultiplier);
             }
             var c = (Color)(settings[0]);
             if (SettingsManager.AbilitySettings.ShowBombColors.Value || c == ThunderspearProjectile.CritColor)

--- a/Assets/Scripts/Utility/Util.cs
+++ b/Assets/Scripts/Utility/Util.cs
@@ -401,5 +401,45 @@ namespace Utility
             // Handle wrap-around
             return (4294967.295 - sentTime) + serverTime;
         }
+
+        private static bool ForceScalableParticleSystemMinMaxCurveMode(ParticleSystem.MinMaxCurve curve, out ParticleSystem.MinMaxCurve newCurve, float scale = 1.0f)
+        {
+            switch (curve.mode)
+            {
+                case ParticleSystemCurveMode.Constant:
+                    newCurve = new ParticleSystem.MinMaxCurve(scale, AnimationCurve.Linear(0.0f, curve.constant, 1.0f, curve.constant));
+                    return true;
+                case ParticleSystemCurveMode.TwoConstants:
+                    newCurve = new ParticleSystem.MinMaxCurve(scale, AnimationCurve.Linear(0.0f, curve.constantMin, 1.0f, curve.constantMax));
+                    return true;
+                default:
+                    newCurve = curve;
+                    return false;
+            }
+        }
+
+        public static void ScaleParticleStartSize(ParticleSystem.MainModule main, float scale)
+        {
+            if (ForceScalableParticleSystemMinMaxCurveMode(main.startSize, out var newCurve, scale))
+            {
+                main.startSize = newCurve;
+            }
+            else
+            {
+                main.startSizeMultiplier = scale;
+            }
+        }
+
+        public static void ScaleParticleStartSpeed(ParticleSystem.MainModule main, float scale)
+        {
+            if (ForceScalableParticleSystemMinMaxCurveMode(main.startSpeed, out var newCurve, scale))
+            {
+                main.startSpeed = newCurve;
+            }
+            else
+            {
+                main.startSpeedMultiplier = scale;
+            }
+        }
     }
 }


### PR DESCRIPTION
I was looking into [this bug report](https://discord.com/channels/681641241125060652/1356121927923798120) from Discord and noticed that it seems to be caused by the particle scale of certain particles (i.e. titan nape blood) blowing up when the titan has its size set multiple times.

## Issue

The existing particle re-scaling code would generally do something like `ParticleSystem.main.startSizeMultiplier *= newSize;` for both `startSizeMultiplier` and `startSpeedMultiplier`. Right away, that doesn't look correct to apply multiple times since it will obviously blow up, which is what is ultimately causing the bug. However, replacing this code with `ParticleSystem.main.startSizeMultiplier = newSize;` causes a different issue: for those `ParticleSystem`s who's `startSize` and/or `startSpeed` had a `mode` of `Constant` or `TwoConstants` (i.e. those that did not use curves), attempting to set the multiplier in this way seems to just set one of the constants to that value, not multiplying anything. I assume this was noticed in the past and that is what resulted in the old code being written as it was.

After [looking into this](https://discussions.unity.com/t/particlesystem-rateovertimemultiplier-and-rateoverdistancemultiplier-not-working-as-expected/658045/10), I determined that scaling properties of particles that use `Constant` or `TwoConstants` mode requires keeping track of the original value somewhere. Rather than duplicate those particle properties from the editor into the code somewhere and try to look them up every time we re-scaled, I opted to convert the properties in those modes to use a (theoretically) equivalent `Curve` mode instead, which actually utilizes the `_____Multiplier` values correctly.

## Fix

I added a couple functions to `Util` to re-scale the `startSize` and `startScale` properties correctly, which will automatically adapt them to the `Curve` mode if needed and replaced all instances in the codebase where these properties were updated to use the new methods.

### Caveats

Instead of solving it this way, it may be preferable to simply update all the relevant particle prefabs to use curves instead of constants for these properties, but I figured it would be more flexible to implement it this way so that simply forgetting to use curves for these properties in the future doesn't cause this weird bug.