### PR TITLE
Chat v4, PM and suggestion fixes

### DIFF
--- a/Assets/Scripts/GameManagers/ChatManager.cs
+++ b/Assets/Scripts/GameManagers/ChatManager.cs
@@ -1315,7 +1315,6 @@ namespace GameManagers
                     }
                     break;
             }            
-            // Add header if we have one
             if (!string.IsNullOrEmpty(header))
             {
                 AddLine(GetColorString(header, ChatTextColor.System), ChatTextColor.System, true, isSuggestion: true);
@@ -1353,6 +1352,11 @@ namespace GameManagers
                 if (panel != null)
                     panel.Sync();
             }
+        }
+
+        public static void ForceSuggestionRefresh()
+        {
+            SuggestionState.PartialText = "\uFFFF";
         }
 
         public static void SendPrivateMessage(Player target, string message)

--- a/Assets/Scripts/GameManagers/InGameManager.cs
+++ b/Assets/Scripts/GameManagers/InGameManager.cs
@@ -346,6 +346,8 @@ namespace GameManagers
                 if (GlobalPause)
                     RPCManager.PhotonView.RPC("PauseGameRPC", player, new object[0]);
             }
+            if (ChatManager.HasActivePlayerSuggestions())
+                ChatManager.RefreshPlayerSuggestions();
         }
 
         public void OnNotifyPlayerJoined(Player player)
@@ -356,6 +358,8 @@ namespace GameManagers
                 string line = player.GetCustomProperty(PlayerProperty.Name) + ChatManager.GetColorString(" has joined the room.", ChatTextColor.System);
                 ChatManager.AddLine(line);
             }
+            if (ChatManager.HasActivePlayerSuggestions())
+                ChatManager.RefreshPlayerSuggestions();
         }
 
         public override void OnPlayerLeftRoom(Player player)
@@ -388,6 +392,8 @@ namespace GameManagers
                 VoiceChatVolumeMultiplier.Remove(player.ActorNumber);
 
             AnticheatManager.ResetVoteKicks(player);
+            if (ChatManager.HasActivePlayerSuggestions())
+                ChatManager.RefreshPlayerSuggestions();
         }
 
         public override void OnMasterClientSwitched(Player newMasterClient)

--- a/Assets/Scripts/UI/InGameMenu/ChatPanel.cs
+++ b/Assets/Scripts/UI/InGameMenu/ChatPanel.cs
@@ -438,7 +438,7 @@ namespace UI
             {
                 emojiCode = $":{emojiName}:";
             }
-            int insertPosition = _inputField.isFocused ? _inputField.caretPosition : text.Length;
+            int insertPosition = text.Length;
             string newText = text.Insert(insertPosition, emojiCode);
             int maxLength = _inputField.characterLimit > 0 ? _inputField.characterLimit : int.MaxValue;
             if (newText.Length > maxLength)
@@ -447,7 +447,7 @@ namespace UI
             }
             string processedText = ProcessEmojiCodes(newText);
             _inputField.SetTextWithoutNotify(processedText);
-            int newCaretPos = insertPosition + emojiCode.Length;
+            int newCaretPos = newText.Length;
             _inputField.caretPosition = newCaretPos;
             _inputField.selectionAnchorPosition = newCaretPos;
             _inputField.selectionFocusPosition = newCaretPos;
@@ -516,8 +516,8 @@ namespace UI
                     true));
             }
             linesToShow.AddRange(regularMessages);
-            linesToShow.AddRange(suggestions);
             linesToShow.AddRange(notifications);
+            linesToShow.AddRange(suggestions);
             UpdateVisibleMessages(linesToShow);
         }
 
@@ -724,23 +724,24 @@ namespace UI
             if (e.type == EventType.KeyDown)
             {
                 bool canHandlePMKeys = IsInputActive() || _isInteractingWithChatUI;
-                
-                if (e.keyCode == KeyCode.Tab && canHandlePMKeys)
+                if (e.keyCode == KeyCode.Tab)
                 {
-                    e.Use();
-                    
-                    if (_inPMMode && _pmPartners.Count > 0)
+                    if (IsInputActive())
                     {
+                        e.Use();
+                        if (_inPMMode && _pmPartners.Count > 0)
+                        {
+                            CycleToPMPartner();
+                        }
+                        else
+                        {
+                            ChatManager.HandleTabComplete();
+                        }
+                    }
+                    else if (_inPMMode && _pmPartners.Count > 0)
+                    {
+                        e.Use();
                         CycleToPMPartner();
-                    }
-                    else if (IsInputActive())
-                    {
-                        ChatManager.HandleTabComplete();
-                    }
-                    else if (_pmPartners.Count > 0)
-                    {
-                        _currentPMIndex = _pmPartners.Count - 1;
-                        EnterPMMode(_pmPartners[_currentPMIndex]);
                     }
                 }
                 else if (e.keyCode == KeyCode.Escape && canHandlePMKeys)
@@ -1277,8 +1278,6 @@ namespace UI
                 Canvas.ForceUpdateCanvases();
             }
         }
-
-
 
         private RectTransform GetCachedRectTransform(GameObject obj)
         {

--- a/Assets/Scripts/UI/InGameMenu/ChatPanel.cs
+++ b/Assets/Scripts/UI/InGameMenu/ChatPanel.cs
@@ -631,6 +631,7 @@ namespace UI
             }
             if (!string.IsNullOrEmpty(_inputField.text))
             {
+                ChatManager.ForceSuggestionRefresh();
                 ChatManager.HandleTyping(_inputField.text);
             }
         }


### PR DESCRIPTION
Continuing #256, #277, #284

Fixed PM and suggestion bugs, with state saving and performance improvements:

-Save PM conversations on restart
-Save PM input field text and caret position when switching chat states & on restart
-Save public chat caret position on restart
-Get PM notifications from other players while already in a PM state
-Player suggestions update dynamically on join/leave
-Suggestions show/hide with chat activation/deactivation
-Optimized suggestions display: reduced from O(3n) to O(n)
-Other related bug fixes