### PR TITLE
Chat DivideByZero error + emoji panel pages (next/back buttons)

### DIFF
--- a/Assets/Resources/UI/Icons/Profile/ProfileIconsAtlas_256.asset
+++ b/Assets/Resources/UI/Icons/Profile/ProfileIconsAtlas_256.asset
@@ -179,6 +179,54 @@ MonoBehaviour:
     m_HashCode: 2126825137
   - m_ElementType: 2
     m_Unicode: 65534
+    m_GlyphIndex: 79
+    m_Scale: 1.1
+    m_Name: ProfileIconsAtlas_256_100
+    m_HashCode: 1125207736
+  - m_ElementType: 2
+    m_Unicode: 65534
+    m_GlyphIndex: 27
+    m_Scale: 1.1
+    m_Name: ProfileIconsAtlas_256_38
+    m_HashCode: 1465753026
+  - m_ElementType: 2
+    m_Unicode: 65534
+    m_GlyphIndex: 40
+    m_Scale: 1.1
+    m_Name: ProfileIconsAtlas_256_53
+    m_HashCode: 1465753103
+  - m_ElementType: 2
+    m_Unicode: 65534
+    m_GlyphIndex: 118
+    m_Scale: 1.1
+    m_Name: ProfileIconsAtlas_256_145
+    m_HashCode: 1125207865
+  - m_ElementType: 2
+    m_Unicode: 65534
+    m_GlyphIndex: 66
+    m_Scale: 1.1
+    m_Name: ProfileIconsAtlas_256_82
+    m_HashCode: 1465752803
+  - m_ElementType: 2
+    m_Unicode: 65534
+    m_GlyphIndex: 52
+    m_Scale: 1.1
+    m_Name: ProfileIconsAtlas_256_76
+    m_HashCode: 1465753160
+  - m_ElementType: 2
+    m_Unicode: 65534
+    m_GlyphIndex: 26
+    m_Scale: 1.1
+    m_Name: ProfileIconsAtlas_256_27
+    m_HashCode: 1465753132
+  - m_ElementType: 2
+    m_Unicode: 65534
+    m_GlyphIndex: 39
+    m_Scale: 1.1
+    m_Name: ProfileIconsAtlas_256_51
+    m_HashCode: 1465753101
+  - m_ElementType: 2
+    m_Unicode: 65534
     m_GlyphIndex: 0
     m_Scale: 1.1
     m_Name: ProfileIconsAtlas_256_0
@@ -195,12 +243,6 @@ MonoBehaviour:
     m_Scale: 1.1
     m_Name: ProfileIconsAtlas_256_2
     m_HashCode: 2126825147
-  - m_ElementType: 2
-    m_Unicode: 65534
-    m_GlyphIndex: 3
-    m_Scale: 1.1
-    m_Name: ProfileIconsAtlas_256_3
-    m_HashCode: 2126825146
   - m_ElementType: 2
     m_Unicode: 65534
     m_GlyphIndex: 4
@@ -317,18 +359,6 @@ MonoBehaviour:
     m_HashCode: 1465753133
   - m_ElementType: 2
     m_Unicode: 65534
-    m_GlyphIndex: 26
-    m_Scale: 1.1
-    m_Name: ProfileIconsAtlas_256_27
-    m_HashCode: 1465753132
-  - m_ElementType: 2
-    m_Unicode: 65534
-    m_GlyphIndex: 27
-    m_Scale: 1.1
-    m_Name: ProfileIconsAtlas_256_38
-    m_HashCode: 1465753026
-  - m_ElementType: 2
-    m_Unicode: 65534
     m_GlyphIndex: 28
     m_Scale: 1.1
     m_Name: ProfileIconsAtlas_256_28
@@ -395,18 +425,6 @@ MonoBehaviour:
     m_HashCode: 1465753027
   - m_ElementType: 2
     m_Unicode: 65534
-    m_GlyphIndex: 39
-    m_Scale: 1.1
-    m_Name: ProfileIconsAtlas_256_51
-    m_HashCode: 1465753101
-  - m_ElementType: 2
-    m_Unicode: 65534
-    m_GlyphIndex: 40
-    m_Scale: 1.1
-    m_Name: ProfileIconsAtlas_256_53
-    m_HashCode: 1465753103
-  - m_ElementType: 2
-    m_Unicode: 65534
     m_GlyphIndex: 42
     m_Scale: 1.1
     m_Name: ProfileIconsAtlas_256_40
@@ -461,12 +479,6 @@ MonoBehaviour:
     m_HashCode: 1465753189
   - m_ElementType: 2
     m_Unicode: 65534
-    m_GlyphIndex: 52
-    m_Scale: 1.1
-    m_Name: ProfileIconsAtlas_256_76
-    m_HashCode: 1465753160
-  - m_ElementType: 2
-    m_Unicode: 65534
     m_GlyphIndex: 54
     m_Scale: 1.1
     m_Name: ProfileIconsAtlas_256_62
@@ -519,18 +531,6 @@ MonoBehaviour:
     m_Scale: 1.1
     m_Name: ProfileIconsAtlas_256_73
     m_HashCode: 1465753165
-  - m_ElementType: 2
-    m_Unicode: 65534
-    m_GlyphIndex: 65
-    m_Scale: 1.1
-    m_Name: ProfileIconsAtlas_256_74
-    m_HashCode: 1465753162
-  - m_ElementType: 2
-    m_Unicode: 65534
-    m_GlyphIndex: 66
-    m_Scale: 1.1
-    m_Name: ProfileIconsAtlas_256_82
-    m_HashCode: 1465752803
   - m_ElementType: 2
     m_Unicode: 65534
     m_GlyphIndex: 67
@@ -605,12 +605,6 @@ MonoBehaviour:
     m_HashCode: 1465752704
   - m_ElementType: 2
     m_Unicode: 65534
-    m_GlyphIndex: 79
-    m_Scale: 1.1
-    m_Name: ProfileIconsAtlas_256_100
-    m_HashCode: 1125207736
-  - m_ElementType: 2
-    m_Unicode: 65534
     m_GlyphIndex: 80
     m_Scale: 1.1
     m_Name: ProfileIconsAtlas_256_91
@@ -675,12 +669,6 @@ MonoBehaviour:
     m_Scale: 1.1
     m_Name: ProfileIconsAtlas_256_103
     m_HashCode: 1125207739
-  - m_ElementType: 2
-    m_Unicode: 65534
-    m_GlyphIndex: 92
-    m_Scale: 1.1
-    m_Name: ProfileIconsAtlas_256_111
-    m_HashCode: 1125207704
   - m_ElementType: 2
     m_Unicode: 65534
     m_GlyphIndex: 95
@@ -803,12 +791,6 @@ MonoBehaviour:
     m_HashCode: 1125207801
   - m_ElementType: 2
     m_Unicode: 65534
-    m_GlyphIndex: 118
-    m_Scale: 1.1
-    m_Name: ProfileIconsAtlas_256_145
-    m_HashCode: 1125207865
-  - m_ElementType: 2
-    m_Unicode: 65534
     m_GlyphIndex: 121
     m_Scale: 1.1
     m_Name: ProfileIconsAtlas_256_132
@@ -843,12 +825,6 @@ MonoBehaviour:
     m_Scale: 1.1
     m_Name: ProfileIconsAtlas_256_136
     m_HashCode: 1125207773
-  - m_ElementType: 2
-    m_Unicode: 65534
-    m_GlyphIndex: 128
-    m_Scale: 1.1
-    m_Name: ProfileIconsAtlas_256_146
-    m_HashCode: 1125207866
   - m_ElementType: 2
     m_Unicode: 65534
     m_GlyphIndex: 129
@@ -929,22 +905,28 @@ MonoBehaviour:
     m_HashCode: 1125207835
   - m_ElementType: 2
     m_Unicode: 65534
-    m_GlyphIndex: 142
+    m_GlyphIndex: 65
     m_Scale: 1.1
-    m_Name: ProfileIconsAtlas_256_160
-    m_HashCode: 1125207934
+    m_Name: ProfileIconsAtlas_256_74
+    m_HashCode: 1465753162
   - m_ElementType: 2
     m_Unicode: 65534
-    m_GlyphIndex: 143
+    m_GlyphIndex: 92
     m_Scale: 1.1
-    m_Name: ProfileIconsAtlas_256_161
-    m_HashCode: 1125207935
+    m_Name: ProfileIconsAtlas_256_111
+    m_HashCode: 1125207704
   - m_ElementType: 2
     m_Unicode: 65534
-    m_GlyphIndex: 145
+    m_GlyphIndex: 3
     m_Scale: 1.1
-    m_Name: ProfileIconsAtlas_256_164
-    m_HashCode: 1125207930
+    m_Name: ProfileIconsAtlas_256_3
+    m_HashCode: 2126825146
+  - m_ElementType: 2
+    m_Unicode: 65534
+    m_GlyphIndex: 128
+    m_Scale: 1.1
+    m_Name: ProfileIconsAtlas_256_146
+    m_HashCode: 1125207866
   m_SpriteGlyphTable:
   - m_Index: 0
     m_Metrics:

--- a/Assets/Scripts/UI/InGameMenu/ChatPanel.cs
+++ b/Assets/Scripts/UI/InGameMenu/ChatPanel.cs
@@ -58,6 +58,7 @@ namespace UI
         private const int MAX_EMOJI_INDEX = 140;
         private Button _emojiNextButton;
         private Button _emojiBackButton;
+        private TextMeshProUGUI _emojiPageText;
         static ChatPanel()
         {
             for (int i = 0; i <= MAX_EMOJI_INDEX; i++)
@@ -400,6 +401,18 @@ namespace UI
             backBtnText.color = Color.white;
             _emojiBackButton = backBtnGo.GetComponent<Button>();
             _emojiBackButton.onClick.AddListener(() => ChangeEmojiPage(-1, tooltipText));
+            var pageTextGo = new GameObject("PageText", typeof(RectTransform), typeof(TextMeshProUGUI));
+            pageTextGo.transform.SetParent(navPanel.transform, false);
+            var pageTextRect = pageTextGo.GetComponent<RectTransform>();
+            pageTextRect.anchorMin = new Vector2(0.5f, 0);
+            pageTextRect.anchorMax = new Vector2(0.5f, 1);
+            pageTextRect.pivot = new Vector2(0.5f, 0.5f);
+            pageTextRect.sizeDelta = new Vector2(60, navButtonHeight);
+            pageTextRect.anchoredPosition = new Vector2(0, 0);
+            _emojiPageText = pageTextGo.GetComponent<TextMeshProUGUI>();
+            _emojiPageText.fontSize = 16;
+            _emojiPageText.alignment = TextAlignmentOptions.Center;
+            _emojiPageText.color = Color.white;
             var nextBtnGo = new GameObject("NextButton", typeof(RectTransform), typeof(Button), typeof(TextMeshProUGUI));
             nextBtnGo.transform.SetParent(navPanel.transform, false);
             var nextBtnRect = nextBtnGo.GetComponent<RectTransform>();
@@ -462,11 +475,16 @@ namespace UI
             }
             _emojiBackButton.interactable = _emojiPage > 0;
             _emojiNextButton.interactable = (end <= MAX_EMOJI_INDEX);
+            if (_emojiPageText != null)
+            {
+                int maxPage = (MAX_EMOJI_INDEX + 1 + EMOJIS_PER_PAGE - 1) / EMOJIS_PER_PAGE;
+                _emojiPageText.text = $"{_emojiPage + 1}/{maxPage}";
+            }
         }
         private void ChangeEmojiPage(int delta, TextMeshProUGUI tooltipText)
         {
-            int maxPage = MAX_EMOJI_INDEX / EMOJIS_PER_PAGE;
-            _emojiPage = Mathf.Clamp(_emojiPage + delta, 0, maxPage);
+            int maxPage = (MAX_EMOJI_INDEX + 1 + EMOJIS_PER_PAGE - 1) / EMOJIS_PER_PAGE;
+            _emojiPage = Mathf.Clamp(_emojiPage + delta, 0, maxPage - 1);
             AddEmojiButtons(tooltipText);
         }
 

--- a/Assets/Scripts/UI/InGameMenu/ChatPanel.cs
+++ b/Assets/Scripts/UI/InGameMenu/ChatPanel.cs
@@ -396,7 +396,7 @@ namespace UI
             backBtnRect.anchoredPosition = new Vector2(10, 0);
             var backBtnText = backBtnGo.GetComponent<TextMeshProUGUI>();
             backBtnText.text = "<";
-            backBtnText.fontSize = 20;
+            backBtnText.fontSize = 14;
             backBtnText.alignment = TextAlignmentOptions.Center;
             backBtnText.color = Color.white;
             _emojiBackButton = backBtnGo.GetComponent<Button>();
@@ -410,7 +410,7 @@ namespace UI
             pageTextRect.sizeDelta = new Vector2(60, navButtonHeight);
             pageTextRect.anchoredPosition = new Vector2(0, 0);
             _emojiPageText = pageTextGo.GetComponent<TextMeshProUGUI>();
-            _emojiPageText.fontSize = 16;
+            _emojiPageText.fontSize = 14;
             _emojiPageText.alignment = TextAlignmentOptions.Center;
             _emojiPageText.color = Color.white;
             var nextBtnGo = new GameObject("NextButton", typeof(RectTransform), typeof(Button), typeof(TextMeshProUGUI));
@@ -423,7 +423,7 @@ namespace UI
             nextBtnRect.anchoredPosition = new Vector2(-10, 0);
             var nextBtnText = nextBtnGo.GetComponent<TextMeshProUGUI>();
             nextBtnText.text = ">";
-            nextBtnText.fontSize = 20;
+            nextBtnText.fontSize = 14;
             nextBtnText.alignment = TextAlignmentOptions.Center;
             nextBtnText.color = Color.white;
             _emojiNextButton = nextBtnGo.GetComponent<Button>();

--- a/Assets/Scripts/UI/InGameMenu/ChatPanel.cs
+++ b/Assets/Scripts/UI/InGameMenu/ChatPanel.cs
@@ -53,9 +53,14 @@ namespace UI
         private Dictionary<GameObject, RectTransform> _cachedRectTransforms = new Dictionary<GameObject, RectTransform>();
         private int _desiredCaretPosition = 0;
         private static readonly Dictionary<string, int> EmojiNameToIndex = new Dictionary<string, int>();
+        private int _emojiPage = 0;
+        private const int EMOJIS_PER_PAGE = 16;
+        private const int MAX_EMOJI_INDEX = 140;
+        private Button _emojiNextButton;
+        private Button _emojiBackButton;
         static ChatPanel()
         {
-            for (int i = 0; i <= 136; i++)
+            for (int i = 0; i <= MAX_EMOJI_INDEX; i++)
             {
                 EmojiNameToIndex[i.ToString()] = i;
             }
@@ -337,11 +342,12 @@ namespace UI
             float cellSize = 40f;
             float spacing = 5f;
             float padding = 15f;
-            float tooltipHeight = 5f;
+            float tooltipHeight = 7f;
+            float navButtonHeight = 15f;
             float gridWidth = (cellSize * 4) + (spacing * 3);
             float gridHeight = (cellSize * 4) + (spacing * 3);
             float totalWidth = gridWidth + (padding * 2);
-            float totalHeight = gridHeight + (padding * 2) + tooltipHeight;
+            float totalHeight = gridHeight + (padding * 2) + tooltipHeight + navButtonHeight;
             emojiPanelRect.sizeDelta = new Vector2(totalWidth, totalHeight);
             var emojiPanelImage = _emojiPanel.GetComponent<Image>();
             emojiPanelImage.color = new Color(0.118f, 0.118f, 0.118f, 0.95f);
@@ -364,13 +370,51 @@ namespace UI
             gridRect.anchorMin = UIAnchors.FullStretchStart;
             gridRect.anchorMax = UIAnchors.FullStretch;
             gridRect.sizeDelta = Vector2.zero;
-            gridRect.offsetMin = new Vector2(padding, padding);
+            gridRect.offsetMin = new Vector2(padding, padding + navButtonHeight);
             gridRect.offsetMax = new Vector2(-padding, -(padding + tooltipHeight));
             var gridLayout = emojiGrid.GetComponent<GridLayoutGroup>();
             gridLayout.cellSize = new Vector2(cellSize, cellSize);
             gridLayout.spacing = new Vector2(spacing, spacing);
             gridLayout.constraint = GridLayoutGroup.Constraint.FixedColumnCount;
             gridLayout.constraintCount = 4;
+            var navPanel = new GameObject("NavPanel", typeof(RectTransform));
+            navPanel.transform.SetParent(_emojiPanel.transform, false);
+            var navRect = navPanel.GetComponent<RectTransform>();
+            navRect.anchorMin = new Vector2(0, 0);
+            navRect.anchorMax = new Vector2(1, 0);
+            navRect.pivot = new Vector2(0.5f, 0f);
+            navRect.sizeDelta = new Vector2(0, navButtonHeight);
+            navRect.anchoredPosition = new Vector2(0, padding / 2);
+            var backBtnGo = new GameObject("BackButton", typeof(RectTransform), typeof(Button), typeof(TextMeshProUGUI));
+            backBtnGo.transform.SetParent(navPanel.transform, false);
+            var backBtnRect = backBtnGo.GetComponent<RectTransform>();
+            backBtnRect.anchorMin = new Vector2(0, 0);
+            backBtnRect.anchorMax = new Vector2(0, 1);
+            backBtnRect.pivot = new Vector2(0, 0.5f);
+            backBtnRect.sizeDelta = new Vector2(60, navButtonHeight);
+            backBtnRect.anchoredPosition = new Vector2(10, 0);
+            var backBtnText = backBtnGo.GetComponent<TextMeshProUGUI>();
+            backBtnText.text = "<";
+            backBtnText.fontSize = 20;
+            backBtnText.alignment = TextAlignmentOptions.Center;
+            backBtnText.color = Color.white;
+            _emojiBackButton = backBtnGo.GetComponent<Button>();
+            _emojiBackButton.onClick.AddListener(() => ChangeEmojiPage(-1, tooltipText));
+            var nextBtnGo = new GameObject("NextButton", typeof(RectTransform), typeof(Button), typeof(TextMeshProUGUI));
+            nextBtnGo.transform.SetParent(navPanel.transform, false);
+            var nextBtnRect = nextBtnGo.GetComponent<RectTransform>();
+            nextBtnRect.anchorMin = new Vector2(1, 0);
+            nextBtnRect.anchorMax = new Vector2(1, 1);
+            nextBtnRect.pivot = new Vector2(1, 0.5f);
+            nextBtnRect.sizeDelta = new Vector2(60, navButtonHeight);
+            nextBtnRect.anchoredPosition = new Vector2(-10, 0);
+            var nextBtnText = nextBtnGo.GetComponent<TextMeshProUGUI>();
+            nextBtnText.text = ">";
+            nextBtnText.fontSize = 20;
+            nextBtnText.alignment = TextAlignmentOptions.Center;
+            nextBtnText.color = Color.white;
+            _emojiNextButton = nextBtnGo.GetComponent<Button>();
+            _emojiNextButton.onClick.AddListener(() => ChangeEmojiPage(1, tooltipText));
             AddEmojiButtons(tooltipText);
             _emojiPanel.SetActive(false);
         }
@@ -378,7 +422,13 @@ namespace UI
         private void AddEmojiButtons(TextMeshProUGUI tooltipText)
         {
             var emojiGrid = _emojiPanel.transform.Find("EmojiGrid").GetComponent<GridLayoutGroup>();
-            for (int i = 0; i < 16; i++)
+            foreach (Transform child in emojiGrid.transform)
+            {
+                Destroy(child.gameObject);
+            }
+            int start = _emojiPage * EMOJIS_PER_PAGE;
+            int end = Mathf.Min(start + EMOJIS_PER_PAGE, MAX_EMOJI_INDEX + 1);
+            for (int i = start; i < end; i++)
             {
                 var buttonGo = new GameObject($"EmojiButton_{i}", typeof(RectTransform), typeof(Button), typeof(Image));
                 buttonGo.transform.SetParent(emojiGrid.transform, false);
@@ -391,7 +441,7 @@ namespace UI
                 emojiTextRect.anchorMax = UIAnchors.CenterMiddle;
                 emojiTextRect.pivot = UIAnchors.CenterMiddle;
                 emojiTextRect.sizeDelta = new Vector2(38, 38);
-                emojiTextRect.anchoredPosition = new Vector2(0, 0); // Move up 3 pixels
+                emojiTextRect.anchoredPosition = new Vector2(0, 0);
                 var tmpText = emojiText.GetComponent<TextMeshProUGUI>();
                 tmpText.text = $"<sprite={i}>";
                 tmpText.fontSize = 30;
@@ -410,6 +460,14 @@ namespace UI
                 exitEntry.callback.AddListener((data) => { tooltipText.text = ""; });
                 tooltipTrigger.triggers.Add(exitEntry);
             }
+            _emojiBackButton.interactable = _emojiPage > 0;
+            _emojiNextButton.interactable = (end <= MAX_EMOJI_INDEX);
+        }
+        private void ChangeEmojiPage(int delta, TextMeshProUGUI tooltipText)
+        {
+            int maxPage = MAX_EMOJI_INDEX / EMOJIS_PER_PAGE;
+            _emojiPage = Mathf.Clamp(_emojiPage + delta, 0, maxPage);
+            AddEmojiButtons(tooltipText);
         }
 
         private void InsertEmoji(int spriteIndex)
@@ -670,6 +728,10 @@ namespace UI
 
         public void ReplaceLastLine(string line)
         {
+            if (POOL_SIZE == 0 || _linesPool.Count == 0)
+            {
+                return;
+            }
             int lastIndex = (_currentLineIndex - 1 + POOL_SIZE) % POOL_SIZE;
             TMP_InputField lineObj = _linesPool[lastIndex];
             if (!lineObj.gameObject.activeSelf)


### PR DESCRIPTION
-Fixed a DivideByZero error caused by CL parsing errors due to its log message being sent before the chat panel is initialized
^Added a check to see if pool size is zero

-Added next & back buttons to change pages in the emoji panel with page number display
-Rearranged some of the emojis order (asset diff)

<img width="298" height="337" alt="Screenshot 2025-07-11 at 6 35 43 PM" src="https://github.com/user-attachments/assets/9f792a80-07ee-4bde-8bd4-77f1aaf5a15f" />

