### PR TITLE
Add I18n builtin

### DIFF
--- a/Assets/Resources/Data/Maps/Mission/Outside the WallsMap.txt
+++ b/Assets/Resources/Data/Maps/Mission/Outside the WallsMap.txt
@@ -1238,6 +1238,7 @@ _playersJustJoined = List();
 
 function OnGameStart()
 {
+Locale.RegisterLanguages("internal://OutsideTheWallsMap");
 ReinforcementZones.Setup(self, self.MaxReinforcementCalls);
 
 if (!self.ReinforcementCallsEnabled)
@@ -2577,7 +2578,7 @@ NetworkMessage()
 coroutine ShowDialogue(key, profileIndex)
 {
 profile = self.Profiles.Get(profileIndex);
-text = UI.GetLocale("OutsideTheWallsMap", "Dialogue", key);
+text = UI.Get("Dialogue." + key);
 Cutscene.ShowDialogue(profile.Icon, profile.Name, text);
 wait 4.0;
 Cutscene.HideDialogue();

--- a/Assets/Resources/Data/Maps/Tutorial/Basic TutorialMap.txt
+++ b/Assets/Resources/Data/Maps/Tutorial/Basic TutorialMap.txt
@@ -24,6 +24,11 @@ class Main
     
     _initialized = false;
 
+    function Init()
+    {
+        Locale.RegisterLanguages("internal://BasicTutorialMap");
+    }
+
     function OnTick()
     {
         if (!self._initialized)
@@ -162,12 +167,12 @@ class IntroductionStage
     {
         Game.SetSong("dakros_origin");
 
-        str = TextStyle.Line(Locale.GetRaw("Introduction.Welcome"));
-        str += TextStyle.Line(Locale.GetRaw("Introduction.Text"));
+        str = TextStyle.Line(Locale.Get("Introduction.Welcome"));
+        str += TextStyle.Line(Locale.Get("Introduction.Text"));
         str += TextStyle.ContinueNextStage("Stage.Movement");
 
-        str = String.Replace(str, "{Name.Tutorial}", TextStyle.Header(Locale.GetRaw("Name.Tutorial")));
-        str = String.Replace(str, "{Name.Game}", TextStyle.Header(Locale.GetRaw("Name.Game")));
+        str = String.Replace(str, "{Name.Tutorial}", TextStyle.Header(Locale.Get("Name.Tutorial")));
+        str = String.Replace(str, "{Name.Game}", TextStyle.Header(Locale.Get("Name.Game")));
 
         Dialogue.ShowDelayed("Stage.Introduction", str, 1.1);
     }
@@ -205,7 +210,7 @@ class MovementStage
         CharacterState.SetRightHookEnabled(false);
         CharacterState.SetSpecial("None");
 
-        str = TextStyle.Line(Locale.GetRaw("Movement.Text"));
+        str = TextStyle.Line(Locale.Get("Movement.Text"));
         str += TextStyle.ContinueNextStage("Stage.Camera");
 
         str = String.Replace(str, "{0}", TextStyle.KeyNames("General/Forward,General/Left,General/Back,General/Right"));
@@ -222,7 +227,7 @@ class MovementStage
 
         # if (!self._started && (Input.GetKeyDown("Interaction/Interact3") || Input.GetKeyDown("General/Forward") || Input.GetKeyDown("General/Back") || Input.GetKeyDown("General/Left") || Input.GetKeyDown("General/Right")))
         # {
-        #     str = Locale.GetRaw("Movement.Forward");
+        #     str = Locale.Get("Movement.Forward");
         #     str = String.Replace(str, "{0}", TextStyle.KeyName("General/Forward"));
         #     Dialogue.Show("Stage.Movement", str);
         #     self._started = true;
@@ -238,7 +243,7 @@ class MovementStage
         #     self._currentTime += Time.FrameTime;
         #     if (self._currentTime >= self.RequiredMoveTime)
         #     {
-        #         str = Locale.GetRaw("Movement.Left");
+        #         str = Locale.Get("Movement.Left");
         #         str = String.Replace(str, "{0}", TextStyle.KeyName("General/Left"));
         #         Dialogue.Show("Stage.Movement", str);
 
@@ -251,7 +256,7 @@ class MovementStage
         #     self._currentTime += Time.FrameTime;
         #     if (self._currentTime >= self.RequiredMoveTime)
         #     {
-        #         str = Locale.GetRaw("Movement.Back");
+        #         str = Locale.Get("Movement.Back");
         #         str = String.Replace(str, "{0}", TextStyle.KeyName("General/Back"));
         #         Dialogue.Show("Stage.Movement", str);
 
@@ -264,7 +269,7 @@ class MovementStage
         #     self._currentTime += Time.FrameTime;
         #     if (self._currentTime >= self.RequiredMoveTime)
         #     {
-        #         str = Locale.GetRaw("Movement.Right");
+        #         str = Locale.Get("Movement.Right");
         #         str = String.Replace(str, "{0}", TextStyle.KeyName("General/Right"));
         #         Dialogue.Show("Stage.Movement", str);
 
@@ -291,7 +296,7 @@ class CameraSwitchStage
 
     function OnStart()
     {
-        str = TextStyle.Line(Locale.GetRaw("Camera.Text"));
+        str = TextStyle.Line(Locale.Get("Camera.Text"));
         str += TextStyle.ContinueNextStage("Stage.SupplyStation");
         str = String.Replace(str, "{0}", TextStyle.KeyName("General/ChangeCamera"));
         Dialogue.Show("Stage.Camera", str);
@@ -331,8 +336,8 @@ class SupplyStationStage
         wait 0.5;
         self._started = true;
 
-        str = TextStyle.Line(Locale.GetRaw("SupplyStation.Text"));
-        str += TextStyle.Instruction(Locale.GetRaw("SupplyStation.Instruction1"));
+        str = TextStyle.Line(Locale.Get("SupplyStation.Text"));
+        str += TextStyle.Instruction(Locale.Get("SupplyStation.Instruction1"));
         str = String.Replace(str, "{0}", TextStyle.KeyName("Human/Reload"));
         str = String.Replace(str, "{1}", TextStyle.KeyName("Interaction/Interact"));
         Dialogue.Show("Stage.SupplyStation", str);
@@ -347,7 +352,7 @@ class SupplyStationStage
 
         if (!self._reloaded && Main.Character.CurrentBladeDurability > 0)
         {
-            str = TextStyle.Instruction(Locale.GetRaw("SupplyStation.Instruction2"));
+            str = TextStyle.Instruction(Locale.Get("SupplyStation.Instruction2"));
             Dialogue.ShowDelayed("Stage.SupplyStation", str, 1.0);
 
             self._reloaded = true;
@@ -395,8 +400,8 @@ class JumpStage
         MapUtils.Checkpoint.Scale = Vector3(sX - 0.05, 0.1, sZ / 2 - 0.05);
         MapUtils.ConfigureCheckpoint("CollisionEnter", self);
 
-        str = TextStyle.Line(Locale.GetRaw("Jump.Text"));
-        str += TextStyle.Instruction(Locale.GetRaw("Jump.Instruction1"));
+        str = TextStyle.Line(Locale.Get("Jump.Text"));
+        str += TextStyle.Instruction(Locale.Get("Jump.Instruction1"));
 
         str = String.Replace(str, "{0}", TextStyle.KeyName("Human/Jump"));
         str = String.Replace(str, "{1}", TextStyle.KeyNames("General/Forward,General/Left,General/Back,General/Right"));
@@ -412,8 +417,8 @@ class JumpStage
         self._count += 1;
         if (self._count == 1)
         {
-            str = TextStyle.Instruction(Locale.GetRaw("Jump.Instruction2"));
-            str = String.Replace(str, "{Stage.Praise$}", Locale.GetRandomPraise());
+            str = TextStyle.Instruction(Locale.Get("Jump.Instruction2"));
+            str = String.Replace(str, "{Stage.Praise$}", LocaleUtil.GetRandomPraise());
             Dialogue.Show("Stage.Jump", str);
 
             Tween.PlayerPosition(self.SpawnPoint).Start();
@@ -450,8 +455,8 @@ class WallRunningStage
         MapUtils.Checkpoint.Scale = Vector3(sX - 0.05, 0.1, sZ / 2 - 0.05);
         MapUtils.ConfigureCheckpoint("CollisionEnter", self);
 
-        str = TextStyle.Line(Locale.GetRaw("WallRun.Text"));
-        str += TextStyle.Instruction(Locale.GetRaw("WallRun.Instruction"));
+        str = TextStyle.Line(Locale.Get("WallRun.Text"));
+        str += TextStyle.Instruction(Locale.Get("WallRun.Instruction"));
         str = String.Replace(str, "{0}", TextStyle.KeyName("General/Forward"));
         Dialogue.Show("Stage.WallRun", str);
     }
@@ -476,7 +481,7 @@ class WallRunningStage
             return;
         }
 
-        str = TextStyle.Line(TextStyle.Header(Locale.GetRandomPraise()));
+        str = TextStyle.Line(TextStyle.Header(LocaleUtil.GetRandomPraise()));
         str += TextStyle.ContinueNextStage("Stage.Hook");
         Dialogue.Show(null, str);
 
@@ -530,8 +535,8 @@ class HookStage
 
         wait 1.1;
 
-        str = TextStyle.Line(Locale.GetRaw("Hook.Text1"));
-        str += TextStyle.Instruction(Locale.GetRaw("Hook.Instruction"));
+        str = TextStyle.Line(Locale.Get("Hook.Text1"));
+        str += TextStyle.Instruction(Locale.Get("Hook.Instruction"));
         str = String.Replace(str, "{0}", TextStyle.KeyName("Human/HookLeft"));
         Dialogue.Show("Stage.Hook", str);
 
@@ -560,7 +565,7 @@ class HookStage
         self._count += 1;
         if (self._count == 1)
         {
-            str = TextStyle.Line(Locale.GetRaw("Hook.Text2"));
+            str = TextStyle.Line(Locale.Get("Hook.Text2"));
             str = String.Replace(str, "{0}", TextStyle.KeyName("Human/HookRight"));
             Dialogue.Show("Stage.Hook", str);
 
@@ -667,8 +672,8 @@ class DashStage
         MapUtils.SinglePlatform.TextureTilingX = 10;
         MapUtils.SinglePlatform.TextureTilingY = 20;
 
-        str = TextStyle.Line(Locale.GetRaw("Dash.Text"));
-        str += TextStyle.Instruction(Locale.GetRaw("Dash.Instruction"));
+        str = TextStyle.Line(Locale.Get("Dash.Text"));
+        str += TextStyle.Instruction(Locale.Get("Dash.Instruction"));
         str = String.Replace(str, "{0}", TextStyle.KeyNames("General/Forward,General/Left,General/Back,General/Right"));
         Dialogue.Show("Stage.Dash", str);
 
@@ -687,7 +692,7 @@ class DashStage
     {
         if (self._started && !self._completed && Main.Character.CurrentAnimation == "Armature|dash")
         {
-            str = TextStyle.Line(Locale.GetRandomPraise());
+            str = TextStyle.Line(LocaleUtil.GetRandomPraise());
             str += TextStyle.ContinueNextStage("Stage.Attack");
             Dialogue.Show(null, str);
 
@@ -714,7 +719,7 @@ class AttackStage
         wait 0.5;
         Tween.Rotation(MapUtils.DummyTitan, Vector3(0, 90, 0)).SetDuration(2).SetEasing("InOutElastic").Start();
 
-        str = TextStyle.Line(Locale.GetRaw("Attack.Text1"));
+        str = TextStyle.Line(Locale.Get("Attack.Text1"));
         str += TextStyle.Continue();
         str = String.Replace(str, "{0}", TextStyle.KeyName("Human/AttackDefault"));
         str = String.Replace(str, "{1}", TextStyle.KeyName("Human/AttackSpecial"));
@@ -757,8 +762,8 @@ class NapeAttackStage
         self._titan.FocusRange = 0;
         self._titan.Rotation = Vector3(0, 90, 0);
 
-        str = TextStyle.Line(Locale.GetRaw("Attack.Text2"));
-        str += TextStyle.Instruction(Locale.GetRaw("Attack.Instruction1"));
+        str = TextStyle.Line(Locale.Get("Attack.Text2"));
+        str += TextStyle.Instruction(Locale.Get("Attack.Instruction1"));
         Dialogue.Show("Stage.Attack", str);
 
         wait 0.3;
@@ -821,8 +826,8 @@ class CrippleStage
     {
         Tween.PlayerPosition(self.SpawnPoint).Start();
 
-        str = TextStyle.Line(Locale.GetRaw("Attack.Text3"));
-        str += TextStyle.Instruction(Locale.GetRaw("Attack.Instruction2"));
+        str = TextStyle.Line(Locale.Get("Attack.Text3"));
+        str += TextStyle.Instruction(Locale.Get("Attack.Instruction2"));
         Dialogue.Show("Stage.Attack", str);
 
         wait 0.9;
@@ -863,8 +868,8 @@ class CrippleStage
                     self._titan.Health = 1;
                     self._learnedCrippling = true;
 
-                    str = TextStyle.Line(Locale.GetRandomPraise());
-                    str += TextStyle.Instruction(Locale.GetRaw("Attack.Instruction$"));
+                    str = TextStyle.Line(LocaleUtil.GetRandomPraise());
+                    str += TextStyle.Instruction(Locale.Get("Attack.Instruction$"));
                     Dialogue.Show(null, str);
                 }
             }
@@ -918,8 +923,8 @@ class BlindStage
     {
         Tween.PlayerPosition(self.SpawnPoint).Start();
 
-        str = TextStyle.Line(Locale.GetRaw("Attack.Text4"));
-        str += TextStyle.Instruction(Locale.GetRaw("Attack.Instruction3"));
+        str = TextStyle.Line(Locale.Get("Attack.Text4"));
+        str += TextStyle.Instruction(Locale.Get("Attack.Instruction3"));
         Dialogue.Show("Stage.Attack", str);
 
         wait 0.9;
@@ -963,8 +968,8 @@ class BlindStage
                     self._titan.MaxHealth = 1;
                     self._titan.Health = 1;
 
-                    str = TextStyle.Line(Locale.GetRandomPraise());
-                    str += TextStyle.Instruction(Locale.GetRaw("Attack.Instruction$"));
+                    str = TextStyle.Line(LocaleUtil.GetRandomPraise());
+                    str += TextStyle.Instruction(Locale.Get("Attack.Instruction$"));
                     Dialogue.Show(null, str);
 
                     self._learnedBlinding = true;
@@ -1007,8 +1012,8 @@ class ArmCutStage
     {
         Tween.PlayerPosition(self.SpawnPoint).Start();
 
-        str = TextStyle.Line(Locale.GetRaw("Attack.Text5"));
-        str += TextStyle.Instruction(Locale.GetRaw("Attack.Instruction4"));
+        str = TextStyle.Line(Locale.Get("Attack.Text5"));
+        str += TextStyle.Instruction(Locale.Get("Attack.Instruction4"));
         Dialogue.Show("Stage.Attack", str);
 
         wait 0.9;
@@ -1048,8 +1053,8 @@ class ArmCutStage
                     self._titan.MaxHealth = 1;
                     self._titan.Health = 1;
 
-                    str = TextStyle.Line(Locale.GetRandomPraise());
-                    str += TextStyle.Instruction(Locale.GetRaw("Attack.Instruction$"));
+                    str = TextStyle.Line(LocaleUtil.GetRandomPraise());
+                    str += TextStyle.Instruction(Locale.Get("Attack.Instruction$"));
                     Dialogue.Show(null, str);
 
                 }
@@ -1113,7 +1118,7 @@ class FightStage
         self._titan = Game.SpawnTitanAt("Normal", Vector3(0, 5, 20));
         self._titan.Size = Random.RandomFloat(1, 2);
 
-        str = TextStyle.Instruction(Locale.GetRaw("Attack.Instruction5"));
+        str = TextStyle.Instruction(Locale.Get("Attack.Instruction5"));
         Dialogue.Show("Stage.Attack", str);
         self.HideDialogue();
     }
@@ -1132,9 +1137,9 @@ class FightStage
     {
         if (victim == self._titan)
         {
-            str = TextStyle.Line(Locale.GetRaw("Stage.Completed"));
-            str = String.Replace(str, "{Stage.Praise$}", Locale.GetRandomPraise());
-            str = String.Replace(str, "{Name.Tutorial}", TextStyle.Header(Locale.GetRaw("Name.Tutorial")));
+            str = TextStyle.Line(Locale.Get("Stage.Completed"));
+            str = String.Replace(str, "{Stage.Praise$}", LocaleUtil.GetRandomPraise());
+            str = String.Replace(str, "{Name.Tutorial}", TextStyle.Header(Locale.Get("Name.Tutorial")));
             Dialogue.Show(null, str);
         }
     }
@@ -1375,17 +1380,17 @@ extension TextStyle
 
     function Continue()
     {
-        str = Locale.GetRaw("Stage.Continue");
+        str = Locale.Get("Stage.Continue");
         str = String.Replace(str, "{0}", self.KeyName("Interaction/Interact3"));
         return self.Instruction(str);
     }
 
     function ContinueNextStage(stageNameSubKey)
     {
-        str = Locale.GetRaw("Stage.Continue");
+        str = Locale.Get("Stage.Continue");
         str += "...({1})";
         str = String.Replace(str, "{0}", self.KeyName("Interaction/Interact3"));
-        str = String.Replace(str, "{1}", Locale.GetRaw(stageNameSubKey));
+        str = String.Replace(str, "{1}", Locale.Get(stageNameSubKey));
         return self.Instruction(str);
     }
 }
@@ -1428,7 +1433,7 @@ extension Dialogue
     {
         if (header != null)
         {
-            header = TextStyle.Header(Locale.GetRaw(header));
+            header = TextStyle.Header(Locale.Get(header));
         }
         else
         {
@@ -1465,21 +1470,12 @@ class Profile
         self.Icon = icon;
     }
 }
-extension Locale
+extension LocaleUtil
 {
-    function GetRaw(subKey)
-    {
-        arr = String.Split(subKey, ".");
-        sub = arr.Get(0);
-        key = arr.Get(1);
-
-        return UI.GetLocale("BasicTutorialMap", sub, key);
-    }
-
     function GetRandomPraise()
     {
         subKey = "Stage.Praise";
-        return self.GetRaw(subKey + Random.RandomInt(1, 4));
+        return Locale.Get(subKey + Random.RandomInt(1, 4));
     }
 }
 # From https:

--- a/Assets/Scripts/CustomLogic/Builtin/CustomLogicLocaleBuiltin.cs
+++ b/Assets/Scripts/CustomLogic/Builtin/CustomLogicLocaleBuiltin.cs
@@ -1,0 +1,244 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Settings;
+using UI;
+
+namespace CustomLogic
+{
+    /// <summary>
+    /// Internationalization (Locale) utility for managing localized strings.
+    /// Supports single-level (non-recursive) language fallbacks and automatic UI language detection.
+    /// </summary>
+    /// <code>
+    /// # Register individual strings for different languages
+    /// Locale.Set(Locale.EnglishLanguage, "welcome", "Welcome to the game!");
+    /// Locale.Set(Locale.RussianLanguage, "welcome", "Добро пожаловать в игру!");
+    /// Locale.Set(Locale.ChineseLanguage, "welcome", "你好");
+    ///
+    /// Game.Print("welcome: " + Locale.Get("welcome"));
+    ///
+    /// # Register multiple strings at once using a dictionary
+    /// englishStrings = Dict();
+    /// englishStrings.Set("hello", "Hello");
+    /// englishStrings.Set("goodbye", "Goodbye");
+    /// englishStrings.Set("score", "Score: {0}");
+    /// Locale.RegisterLanguage(Locale.EnglishLanguage, englishStrings);
+    ///
+    /// russianStrings = Dict();
+    /// russianStrings.Set("hello", "Привет");
+    /// russianStrings.Set("goodbye", "Пока");
+    /// russianStrings.Set("score", "Счет: {0}");
+    /// Locale.RegisterLanguage(Locale.RussianLanguage, russianStrings);
+    ///
+    /// chineseStrings = Dict();
+    /// chineseStrings.Set("hello", "你好");
+    /// chineseStrings.Set("goodbye", "再见");
+    /// chineseStrings.Set("score", "分数: {0}");
+    /// Locale.RegisterLanguage(Locale.ChineseLanguage, chineseStrings);
+    ///
+    /// # Get localized strings (automatically uses current UI language)
+    /// Game.Print("hello: " + Locale.Get("hello"));
+    /// Game.Print("goodbye: " + Locale.Get("goodbye"));
+    /// 
+    /// params = List();
+    /// params.Add(83);
+    /// Game.Print("score: " + String.FormatFromList(Locale.Get("score"), params));
+    ///
+    /// # Register all strings from internal JSON files for a specific category
+    /// # Use internal:// prefix to specify internal localization files
+    /// Locale.RegisterLanguages("internal://BasicTutorialMap");
+    /// 
+    /// Game.Print("Name.Game: " + Locale.Get("Name.Game"));
+    /// Game.Print("Name.Tutorial: " + Locale.Get("Name.Tutorial"));
+    /// Game.Print("Stage.Introduction: " + Locale.Get("Stage.Introduction"));
+    /// 
+    /// # Register all strings from external JSON files
+    /// # Without prefix, treats as external localization files
+    /// # Path: Documents/Aottg2/CustomLocale/MyGameMode/English.json
+    /// # JSON file structure:
+    /// {
+    ///     "Name": "English",  // Required header
+    ///     "Hello": "World!",  // Localization values
+    ///     "Foo.Bar": "Baz"    // Localization values
+    /// }
+    /// 
+    /// Locale.RegisterLanguages("MyGameMode");
+    /// 
+    /// Game.Print("Hello: " + Locale.Get("Hello"));
+    /// Game.Print("Foo.Bar: " + Locale.Get("Foo.Bar"));
+    /// 
+    /// # Registering non-existing or empty localization files directory will throw an exception
+    /// Locale.RegisterLanguages("NonExistingGameMode");
+    ///
+    /// # Set default fallback language (Russian instead of English)
+    /// Locale.DefaultLanguage = Locale.RussianLanguage;
+    ///
+    /// # Fallback to default for missing key in current language
+    /// Locale.Set(Locale.RussianLanguage, "russian_key", "Сообщение");
+    /// Game.Print("russian_key: " + Locale.Get("russian_key"));
+    ///
+    /// # Single-level (non-recursive) fallback: English -> German
+    /// Locale.RegisterFallback(Locale.EnglishLanguage, Locale.GermanLanguage);
+    /// Locale.Set(Locale.GermanLanguage, "german_string", "Hallo");
+    /// Game.Print("german_string: " + Locale.Get("german_string"));
+    ///
+    /// # By default Traditional Chinese falls back to Simplified Chinese
+    /// Locale.Set(Locale.ChineseLanguage, "chinese_string", "你好");
+    /// Game.Print("chinese_string: " + Locale.Get("chinese_string"));
+    ///
+    /// # Clean up fallbacks
+    /// Locale.RemoveFallback(Locale.ChineseLanguage);
+    /// Locale.RemoveFallback(Locale.TraditionalChineseLanguage);
+    ///
+    /// # Missing key throws an exception
+    /// Game.Print("missing_key: " + Locale.Get("missing_key"));
+    /// </code>
+    [CLType(Name = "Locale", Static = true)]
+    partial class CustomLogicLocaleBuiltin : BuiltinClassInstance
+    {
+        private static readonly Dictionary<string, Dictionary<string, string>> _languages = new Dictionary<string, Dictionary<string, string>>();
+        private static readonly Dictionary<string, string> _languageFallbacks = new Dictionary<string, string>();
+
+        [CLConstructor]
+        public CustomLogicLocaleBuiltin()
+        {
+            DefaultLanguage = EnglishLanguage;
+
+            RegisterFallback(TraditionalChineseLanguage, ChineseLanguage);
+            RegisterFallback(ChineseLanguage, TraditionalChineseLanguage);
+        }
+
+        [CLProperty(readOnly: true, description: "Arabic language code")]
+        public static string ArabicLanguage => UILanguages.Arabic;
+
+        [CLProperty(readOnly: true, description: "Brazilian Portuguese language code")]
+        public static string BrazilianPortugueseLanguage => UILanguages.BrazilianPortuguese;
+
+        [CLProperty(readOnly: true, description: "Chinese language code")]
+        public static string ChineseLanguage => UILanguages.Chinese;
+
+        [CLProperty(readOnly: true, description: "Czech language code")]
+        public static string CzechLanguage => UILanguages.Czech;
+
+        [CLProperty(readOnly: true, description: "Dutch language code")]
+        public string DutchLanguage => UILanguages.Dutch;
+
+        [CLProperty(readOnly: true, description: "English language code")]
+        public static string EnglishLanguage => UILanguages.English;
+
+        [CLProperty(readOnly: true, description: "French language code")]
+        public static string FrenchLanguage => UILanguages.French;
+
+        [CLProperty(readOnly: true, description: "German language code")]
+        public static string GermanLanguage => UILanguages.German;
+
+        [CLProperty(readOnly: true, description: "Greek language code")]
+        public static string GreekLanguage => UILanguages.Greek;
+
+        [CLProperty(readOnly: true, description: "Indonesian language code")]
+        public static string IndonesianLanguage => UILanguages.Indonesian;
+
+        [CLProperty(readOnly: true, description: "Italian language code")]
+        public static string ItalianLanguage => UILanguages.Italian;
+
+        [CLProperty(readOnly: true, description: "Japanese language code")]
+        public static string JapaneseLanguage => UILanguages.Japanese;
+
+        [CLProperty(readOnly: true, description: "Korean language code")]
+        public static string KoreanLanguage => UILanguages.Korean;
+
+        [CLProperty(readOnly: true, description: "Polish language code")]
+        public static string PolishLanguage => UILanguages.Polish;
+
+        [CLProperty(readOnly: true, description: "Russian language code")]
+        public static string RussianLanguage => UILanguages.Russian;
+
+        [CLProperty(readOnly: true, description: "Spanish language code")]
+        public static string SpanishLanguage => UILanguages.Spanish;
+
+        [CLProperty(readOnly: true, description: "Traditional Chinese language code")]
+        public static string TraditionalChineseLanguage => UILanguages.TraditionalChinese;
+
+        [CLProperty(readOnly: true, description: "Turkish language code")]
+        public static string TurkishLanguage => UILanguages.Turkish;
+
+        [CLProperty(readOnly: true, description: "Ukrainian language code")]
+        public static string UkrainianLanguage => UILanguages.Ukrainian;
+
+        [CLProperty(readOnly: true, description: "Returns the current language (e.g. \"English\" or \"简体中文\").")]
+        public static string CurrentLanguage => SettingsManager.GeneralSettings.Language.Value;
+
+        [CLProperty(description: "The default language to use when a string is not found in the current language pack. English by default.")]
+        public static string DefaultLanguage { get; set; }
+
+        [CLMethod(description: "Get the localized string for the given key. Searches the current UI language, then any registered fallbacks, and finally the default language. Throws an exception if the key is not found in any language pack.")]
+        public static string Get(string key)
+        {
+            var currentLang = SettingsManager.GeneralSettings.Language.Value;
+
+            var value = ResolveString(key, currentLang);
+            if (value != null)
+                return value;
+
+            throw new Exception("Localized string not found: " + key);
+        }
+
+        [CLMethod(description: "Set or override a localized string for the specified language and key.")]
+        public static void Set(string language, string key, string value)
+        {
+            if (!_languages.TryGetValue(language, out var languagePack))
+            {
+                languagePack = new Dictionary<string, string>();
+                _languages[language] = languagePack;
+            }
+
+            languagePack[key] = value;
+        }
+
+        [CLMethod(description: "Register a single-level (non-recursive) fallback: if a string is not found in 'fromLanguage', the system will search only in 'toLanguage', without chaining further.")]
+        public static void RegisterLanguage(string language, CustomLogicDictBuiltin strings)
+        {
+            var dictionary = new Dictionary<string, string>(strings.Dict.Count);
+            foreach (var pair in strings.Dict)
+                dictionary[pair.Key.ToString()] = pair.Value.ToString();
+            _languages[language] = dictionary;
+        }
+
+        [CLMethod(description: "Register all localized strings from JSON files for a specific category across all available languages. Use 'internal://' prefix for internal files (e.g., 'internal://BasicTutorialMap') or no prefix for external files (e.g., 'MyCustomMod').")]
+        public static void RegisterLanguages(string pattern)
+        {
+            foreach (var languagePair in UIManager.GetLocaleCategoryStrings(pattern))
+                _languages[languagePair.Key] = languagePair.Value;
+        }
+
+        [CLMethod(description: "Register a fallback language. When a string is not found in 'fromLanguage', it will try 'toLanguage'.")]
+        public static void RegisterFallback(string fromLanguage, string toLanguage)
+        {
+            _languageFallbacks[fromLanguage] = toLanguage;
+        }
+
+        [CLMethod(description: "Remove a language fallback.")]
+        public static void RemoveFallback(string fromLanguage)
+        {
+            _languageFallbacks.Remove(fromLanguage);
+        }
+
+        private static string ResolveString(string key, string requestedLang)
+        {
+            if (_languages.TryGetValue(requestedLang, out var exactPack) && exactPack.TryGetValue(key, out var exactValue))
+                return exactValue;
+
+            if (_languageFallbacks.TryGetValue(requestedLang, out var fallbackLang)
+                && _languages.TryGetValue(fallbackLang, out var fallbackPack)
+                && fallbackPack.TryGetValue(key, out var fallbackValue))
+                return fallbackValue;
+
+            if (_languages.TryGetValue(DefaultLanguage, out var defaultPack)
+                && defaultPack.TryGetValue(key, out var defaultValue))
+                return defaultValue;
+
+            throw new Exception("Locale string not found: " + key);
+        }
+    }
+}

--- a/Assets/Scripts/CustomLogic/Builtin/CustomLogicLocaleBuiltin.cs.meta
+++ b/Assets/Scripts/CustomLogic/Builtin/CustomLogicLocaleBuiltin.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a10bcef8fe6d69d44a8fbc9869e41548
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/CustomLogic/Builtin/CustomLogicUIBuiltin.cs
+++ b/Assets/Scripts/CustomLogic/Builtin/CustomLogicUIBuiltin.cs
@@ -154,12 +154,6 @@ namespace CustomLogic
             return $"<{style}={arg}>{text}</{style}>";
         }
 
-        /// <summary>Gets translated locale from the current Language.json file with given category, subcategory, and key pattern.</summary>
-        [CLMethod] public static string GetLocale(string cat, string sub, string key) => UIManager.GetLocale(cat, sub, key);
-
-        /// <summary>Returns the current language (e.g. "English" or "简体中文").</summary>
-        [CLMethod] public static string GetLanguage() => SettingsManager.GeneralSettings.Language.Value;
-
         /// <summary>Shows the change character menu if main character is Human.</summary>
         [CLMethod]
         public static void ShowChangeCharacterMenu()

--- a/Assets/Scripts/UI/UILanguages.cs
+++ b/Assets/Scripts/UI/UILanguages.cs
@@ -1,0 +1,25 @@
+﻿namespace UI
+{
+    static class UILanguages
+    {
+        public const string Arabic = "العربية";
+        public const string BrazilianPortuguese = "PT-BR";
+        public const string Chinese = "简体中文";
+        public const string Czech = "Čeština";
+        public const string Dutch = "Dutch";
+        public const string English = "English";
+        public const string French = "Français";
+        public const string German = "Deutsch";
+        public const string Greek = "Ελληνικά";
+        public const string Indonesian = "Indonesian";
+        public const string Italian = "Italiano";
+        public const string Japanese = "日本語";
+        public const string Korean = "한국어";
+        public const string Polish = "Polski";
+        public const string Russian = "Russian";
+        public const string Spanish = "Español";
+        public const string TraditionalChinese = "繁體中文";
+        public const string Turkish = "Türkçe";
+        public const string Ukrainian = "Українська";
+    }
+}

--- a/Assets/Scripts/UI/UILanguages.cs.meta
+++ b/Assets/Scripts/UI/UILanguages.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 201210fa70d47274687ec7ba860bc654
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Utility/FolderPaths.cs
+++ b/Assets/Scripts/Utility/FolderPaths.cs
@@ -24,5 +24,6 @@ namespace Utility
         public static string CustomMapAutosave = Documents + "/CustomMap/Autosave";
         public static string CustomAssetsLocal = Documents + "/CustomAssets";
         public static string CustomAssetsWeb = Documents + "/CustomAssets/WebDownload";
+        public static string CustomLocale = Documents + "/CustomLocale";
     }
 }


### PR DESCRIPTION
- Added Locale custom logic builtin module. (refer to CL example for usage)
- Removed UI.GetLocale() method.
- Moved UI.CurrentLanguage to Locale.CurrentLanguage
- Registered path for Custom Locale files.
- Added method to UIManager to parse internal and external localization files / strings.
- Updated Tutorial and Outside the Walls maps to use new Locale module.

Test CL:

```cs
class Main
{
	function OnGameStart()
	{
		# Register individual strings for different languages
		Locale.Set(Locale.EnglishLanguage, "welcome", "Welcome to the game!");
		Locale.Set(Locale.RussianLanguage, "welcome", "Добро пожаловать в игру!");
		Locale.Set(Locale.ChineseLanguage, "welcome", "你好");

		Game.Print("welcome: " + Locale.Get("welcome"));

		# Register multiple strings at once using a dictionary
		englishStrings = Dict();
		englishStrings.Set("hello", "Hello");
		englishStrings.Set("goodbye", "Goodbye");
		englishStrings.Set("score", "Score: {0}");
		Locale.RegisterLanguage(Locale.EnglishLanguage, englishStrings);

		russianStrings = Dict();
		russianStrings.Set("hello", "Привет");
		russianStrings.Set("goodbye", "Пока");
		russianStrings.Set("score", "Счет: {0}");
		Locale.RegisterLanguage(Locale.RussianLanguage, russianStrings);

		chineseStrings = Dict();
		chineseStrings.Set("hello", "你好");
		chineseStrings.Set("goodbye", "再见");
		chineseStrings.Set("score", "分数: {0}");
		Locale.RegisterLanguage(Locale.ChineseLanguage, chineseStrings);

		# Get localized strings (automatically uses current UI language)
		Game.Print("hello: " + Locale.Get("hello"));
		Game.Print("goodbye: " + Locale.Get("goodbye"));

		params = List();
		params.Add("83");
		Game.Print("score: " + String.FormatFromList(Locale.Get("score"), params));

		# Register all strings from internal JSON files for built‑in maps
        # Use internal:// prefix to specify internal localization files
		Locale.RegisterLanguages("internal://BasicTutorialMap");
		Game.Print("Name.Game: " + Locale.Get("Name.Game"));
		Game.Print("Name.Tutorial: " + Locale.Get("Name.Tutorial"));
		Game.Print("Stage.Introduction: " + Locale.Get("Stage.Introduction"));

		# Register all strings from external JSON files for a custom mod
		# Without prefix, treats as external localization files
		# Path: Documents/Aottg2/CustomLocale/MyGameMode/English.json
		Locale.RegisterLanguages("MyGameMode");
		Game.Print("Hello: " + Locale.Get("Hello"));
		Game.Print("Foo.Bar: " + Locale.Get("Foo.Bar"));

        # Registering non-existing or empty localization files directory will throw an exception
        Locale.RegisterLanguages("NonExistingGameMode");

		# Set default fallback language (English by default)
		Locale.DefaultLanguage = Locale.RussianLanguage;

		# Fallback to default for missing key in current language
		Locale.Set(Locale.RussianLanguage, "russian_key", "Сообщение");
		Game.Print("russian_key: " + Locale.Get("russian_key"));

		# Single-level (non-recursive) fallback: English -> German
		Locale.RegisterFallback(Locale.EnglishLanguage, Locale.GermanLanguage);
		Locale.Set(Locale.GermanLanguage, "german_string", "Hallo");
		Game.Print("german_string: " + Locale.Get("german_string"));  # checks English, then one lookup in German only

		# By default Traditional Chinese falls back to Simplified Chinese
		Locale.Set(Locale.ChineseLanguage, "chinese_string", "你好");
		Game.Print("chinese_string: " + Locale.Get("chinese_string"));

		# Clean up fallbacks
		Locale.RemoveFallback(Locale.ChineseLanguage);
		Locale.RemoveFallback(Locale.TraditionalChineseLanguage);

		# Missing key throws an exception
		Game.Print("missing_key: " + Locale.Get("missing_key"));
	}
}
```