### PR TITLE
Fixed CL String.FormatFromList() method

### DIFF
--- a/Assets/Scripts/CustomLogic/Builtin/CustomLogicStringBuiltin.cs
+++ b/Assets/Scripts/CustomLogic/Builtin/CustomLogicStringBuiltin.cs
@@ -25,12 +25,7 @@ namespace CustomLogic
         [CLMethod("Equivalent to C# string.format(string, List<string>).")]
         public static string FormatFromList(string str, CustomLogicListBuiltin list)
         {
-            var strList = new List<string>();
-            foreach (var obj in list.List)
-            {
-                strList.Add((string)obj);
-            }
-            return string.Format(str, strList);
+            return string.Format(str, list.List.ToArray());
         }
 
         [CLMethod("Split the string into a list. Can pass in either a string to split on or a list of strings to split on, the last optional param can remove all empty entries.")]


### PR DESCRIPTION
Fixed `string.Format` usage.
Now also supports different collection values types, not only string.

```cs
params = List();
params.Add("83");
Game.Print("score: " + String.FormatFromList("Score: {0}"), params));
```

<img width="290" height="15" alt="image" src="https://github.com/user-attachments/assets/3f7ea072-11a3-42c1-af11-fb9faeb8c38d" />
