### PR TITLE
Clear chat input field text when player sends whitespace

### DIFF
--- a/Assets/Scripts/UI/InGameMenu/ChatPanel.cs
+++ b/Assets/Scripts/UI/InGameMenu/ChatPanel.cs
@@ -720,6 +720,7 @@ namespace UI
             {
                 ChatManager.ClearLastSuggestions();
                 IgnoreNextActivation = true;
+                _inputField.text = "";
                 _inputField.DeactivateInputField();
                 return;
             }


### PR DESCRIPTION
Just white space doesn't get sent anymore but the chat input field text doesn't get cleared.
<img width="229" height="79" alt="image" src="https://github.com/user-attachments/assets/db586468-5dd0-4b91-b54d-18bc9610c74e" />
