### PR TITLE
Chat PM's & Rich Tags

### DIFF
--- a/Assets/Scripts/GameManagers/ChatManager.cs
+++ b/Assets/Scripts/GameManagers/ChatManager.cs
@@ -92,9 +92,8 @@ namespace GameManagers
         private static readonly StringBuilder MessageBuilder = new StringBuilder(256);
         private static readonly StringBuilder TimeBuilder = new StringBuilder(8);
         private static readonly StringBuilder MentionBuilder = new StringBuilder(256);
-
-        private static readonly Dictionary<int, DateTime> ActivePMNotifications = new Dictionary<int, DateTime>();
-        private static readonly float NOTIFICATION_DURATION = 3.0f;
+        private static readonly HashSet<int> ActivePMNotifications = new HashSet<int>();
+        private static readonly HashSet<int> NotifiedPMs = new HashSet<int>();
 
         private static class SuggestionState
         {
@@ -191,6 +190,10 @@ namespace GameManagers
             _conversationTexts.Remove(key);
             _conversationCarets.Remove(key);
         }
+        public static void ResetNotifiedForPM(int pmId)
+        {
+            NotifiedPMs.Remove(pmId);
+        }
 
         public static void Init()
         {
@@ -259,6 +262,7 @@ namespace GameManagers
                     feedPanel.Sync();
             }
             ActivePMNotifications.Clear();
+            NotifiedPMs.Clear();
         }
 
         public static bool IsChatActive()
@@ -302,6 +306,7 @@ namespace GameManagers
         public static void AddLine(string message, ChatTextColor color = ChatTextColor.Default, bool isSystem = false, DateTime? timestamp = null, int senderID = -1, bool isSuggestion = false, bool isPM = false, int pmPartnerID = -1, bool isNotification = false)
         {
             message = message.FilterSizeTag();
+            message = MiscExtensions.ReplaceNamedColorTags(message);
             string formattedMessage = GetColorString(message, color);
             DateTime messageTime = timestamp ?? DateTime.UtcNow;
             RawMessages.Add(formattedMessage);
@@ -974,7 +979,6 @@ namespace GameManagers
                         chatPanel.Activate();
                 }
             }
-            UpdatePMNotifications();
         }
 
         public static void HandleTyping(string input)
@@ -1715,41 +1719,27 @@ namespace GameManagers
         {
             if (senderPlayer == null) return;
             int senderID = senderPlayer.ActorNumber;
-            DateTime currentTime = DateTime.UtcNow;
-            if (ActivePMNotifications.ContainsKey(senderID))
-            {
-                ActivePMNotifications[senderID] = currentTime;
+            if (NotifiedPMs.Contains(senderID))
                 return;
-            }
-            ActivePMNotifications[senderID] = currentTime;
+            NotifiedPMs.Add(senderID);
+            if (ActivePMNotifications.Contains(senderID))
+                return;
+            ActivePMNotifications.Add(senderID);
+            DateTime currentTime = DateTime.UtcNow;
             var chatPanel = GetChatPanel();
-            bool isInPMMode = chatPanel != null && chatPanel.IsInPMMode();
-            string prompt = isInPMMode ? " (Tab)" : " (Esc)";
+            string prompt = " (Tab)";
             string notificationText = $"{GetColorString("New message from ", ChatTextColor.System)}{GetPlayerIdentifier(senderPlayer)}{GetColorString(prompt, ChatTextColor.System)}";
             AddLine(notificationText, ChatTextColor.MyPlayer, true, currentTime, senderID, false, false, -1, true);
-        }
-
-        public static void UpdatePMNotifications()
-        {
-            DateTime currentTime = DateTime.UtcNow;
-            var expiredNotifications = new List<int>();
-            foreach (var kvp in ActivePMNotifications)
-            {
-                if ((currentTime - kvp.Value).TotalSeconds >= NOTIFICATION_DURATION)
-                {
-                    expiredNotifications.Add(kvp.Key);
-                }
-            }
-            foreach (int playerID in expiredNotifications)
-            {
-                ActivePMNotifications.Remove(playerID);
-                ClearPMNotificationFromChat(playerID);
-            }
         }
 
         public static bool HasActivePlayerSuggestions()
         {
             return SuggestionState.IsActive && (SuggestionState.Type == SuggestionType.PlayerID || SuggestionState.Type == SuggestionType.Mention);
+        }
+
+        public static bool HasActiveSuggestions()
+        {
+            return SuggestionState.IsActive;
         }
 
         public static void RefreshPlayerSuggestions()
@@ -1796,16 +1786,15 @@ namespace GameManagers
 
         public static void ClearPMNotification(int playerID)
         {
-            if (ActivePMNotifications.ContainsKey(playerID))
+            if (ActivePMNotifications.Contains(playerID))
             {
                 ActivePMNotifications.Remove(playerID);
-                ClearPMNotificationFromChat(playerID);
             }
         }
 
         public static bool HasActivePMNotification(int playerID)
         {
-            return ActivePMNotifications.ContainsKey(playerID);
+            return ActivePMNotifications.Contains(playerID);
         }
 
         private static void UpdatePartialTextAfterCompletion(string newText, string chosen)

--- a/Assets/Scripts/UI/InGameMenu/ChatPanel.cs
+++ b/Assets/Scripts/UI/InGameMenu/ChatPanel.cs
@@ -149,36 +149,6 @@ namespace UI
                 return addedChar;
             };
             _inputField.onFocusSelectAll = false;
-            _inputField.onSelect.AddListener((value) => {
-                string clip = GUIUtility.systemCopyBuffer ?? string.Empty;
-                if (string.IsNullOrEmpty(clip)) return;
-                clip = clip.Replace("\n", string.Empty)
-                           .Replace("\r", string.Empty)
-                           .Replace("\u001B", string.Empty);
-                bool matchedChat = false;
-                try
-                {
-                    for (int i = 0; i < ChatManager.RawMessages.Count; i++)
-                    {
-                        string stored = ChatManager.RawMessages[i];
-                        if (string.IsNullOrEmpty(stored)) continue;
-                        if (string.Equals(stored, clip, StringComparison.Ordinal) || stored.Contains(clip) || clip.Contains(stored))
-                        {
-                            matchedChat = true;
-                            break;
-                        }
-                    }
-                }
-                catch
-                {
-                    matchedChat = false;
-                }
-                if (matchedChat)
-                {
-                    clip = clip.StripRichText();
-                }
-                GUIUtility.systemCopyBuffer = clip;
-            });
             var nav = _inputField.navigation;
             nav.mode = Navigation.Mode.None;
             _inputField.navigation = nav;

--- a/Assets/Scripts/UI/InGameMenu/ChatPanel.cs
+++ b/Assets/Scripts/UI/InGameMenu/ChatPanel.cs
@@ -131,6 +131,7 @@ namespace UI
             textRect.sizeDelta = Vector2.zero;
             var tmpText = textComponent.GetComponent<TextMeshProUGUI>();
             tmpText.enableWordWrapping = false;
+            tmpText.richText = false;
             tmpText.overflowMode = TextOverflowModes.ScrollRect;
             tmpText.horizontalAlignment = HorizontalAlignmentOptions.Left;
             tmpText.verticalAlignment = VerticalAlignmentOptions.Middle;
@@ -138,9 +139,9 @@ namespace UI
             _inputField.textViewport = textAreaRect;
             _inputField.textComponent = tmpText;
             _inputField.lineType = TMP_InputField.LineType.SingleLine;
+            _inputField.richText = false;
             _inputField.inputType = TMP_InputField.InputType.Standard;
             _inputField.scrollSensitivity = 60f;
-            // Add paste handler to strip rich text (except sprites) and line breaks
             _inputField.onValidateInput += (text, charIndex, addedChar) =>
             {
                 if (addedChar == '\n' || addedChar == '\r' || addedChar == '\u001B' || addedChar == (char)27)
@@ -149,15 +150,34 @@ namespace UI
             };
             _inputField.onFocusSelectAll = false;
             _inputField.onSelect.AddListener((value) => {
-                if (GUIUtility.systemCopyBuffer.Length > 0)
+                string clip = GUIUtility.systemCopyBuffer ?? string.Empty;
+                if (string.IsNullOrEmpty(clip)) return;
+                clip = clip.Replace("\n", string.Empty)
+                           .Replace("\r", string.Empty)
+                           .Replace("\u001B", string.Empty);
+                bool matchedChat = false;
+                try
                 {
-                    string clipText = GUIUtility.systemCopyBuffer;
-                    clipText = Regex.Replace(clipText, @"<(?!sprite=)[^>]+>|</[^>]+>", string.Empty) // Keep sprite tags
-                        .Replace("\n", string.Empty)
-                        .Replace("\r", string.Empty)
-                        .Replace("\u001B", string.Empty);
-                    GUIUtility.systemCopyBuffer = clipText;
+                    for (int i = 0; i < ChatManager.RawMessages.Count; i++)
+                    {
+                        string stored = ChatManager.RawMessages[i];
+                        if (string.IsNullOrEmpty(stored)) continue;
+                        if (string.Equals(stored, clip, StringComparison.Ordinal) || stored.Contains(clip) || clip.Contains(stored))
+                        {
+                            matchedChat = true;
+                            break;
+                        }
+                    }
                 }
+                catch
+                {
+                    matchedChat = false;
+                }
+                if (matchedChat)
+                {
+                    clip = clip.StripRichText();
+                }
+                GUIUtility.systemCopyBuffer = clip;
             });
             var nav = _inputField.navigation;
             nav.mode = Navigation.Mode.None;
@@ -198,7 +218,7 @@ namespace UI
             var (text, caretPos) = ChatManager.GetConversation("PUBLIC");
             if (!string.IsNullOrEmpty(text))
             {
-                _inputField.text = text;
+                _inputField.text = text.StripRichText();
                 _desiredCaretPosition = caretPos;
             }
             else
@@ -206,7 +226,7 @@ namespace UI
                 var (preservedText, preservedCaret) = ChatManager.GetPreservedInputWithCaret();
                 if (!string.IsNullOrEmpty(preservedText))
                 {
-                    _inputField.text = preservedText;
+                    _inputField.text = preservedText.StripRichText();
                     _desiredCaretPosition = preservedCaret;
                 }
             }
@@ -523,18 +543,24 @@ namespace UI
 
         private void RefreshDisplayedMessages()
         {
-            List<string> regularMessages = new List<string>();
+            List<string> linesToShow = new List<string>();
             List<string> suggestions = new List<string>();
-            List<string> notifications = new List<string>();
+            if (_inPMMode && _currentPMTarget != null)
+            {
+                linesToShow.Add(ChatManager.GetFormattedMessage(
+                    $"{ChatManager.GetColorString("Private chat with ", ChatTextColor.System)}{ChatManager.GetPlayerIdentifier(_currentPMTarget)}",
+                    DateTime.Now,
+                    true));
+            }
             for (int i = 0; i < ChatManager.RawMessages.Count; i++)
             {
                 if (_inPMMode && _currentPMTarget != null)
                 {
-                    if (ChatManager.PrivateFlags[i] && 
+                    if (ChatManager.PrivateFlags[i] &&
                         (ChatManager.PMPartnerIDs[i] == _currentPMTarget.ActorNumber ||
                          ChatManager.SenderIDs[i] == _currentPMTarget.ActorNumber))
                     {
-                        regularMessages.Add(ChatManager.GetFormattedMessage(
+                        linesToShow.Add(ChatManager.GetFormattedMessage(
                             ChatManager.RawMessages[i],
                             ChatManager.Timestamps[i],
                             ChatManager.SuggestionFlags[i]));
@@ -542,40 +568,30 @@ namespace UI
                 }
                 else
                 {
-                    if (ChatManager.NotificationFlags[i])
-                    {
-                        notifications.Add(ChatManager.GetFormattedMessage(
-                            ChatManager.RawMessages[i],
-                            ChatManager.Timestamps[i],
-                            ChatManager.NotificationFlags[i]));
-                    }
-                    else if (ChatManager.SuggestionFlags[i])
+                    if (ChatManager.SuggestionFlags[i])
                     {
                         suggestions.Add(ChatManager.GetFormattedMessage(
                             ChatManager.RawMessages[i],
                             ChatManager.Timestamps[i],
                             ChatManager.SuggestionFlags[i]));
                     }
-                    else if ((!ChatManager.PrivateFlags[i] || ChatManager.SystemFlags[i]) && 
+                    else if (ChatManager.NotificationFlags[i])
+                    {
+                        linesToShow.Add(ChatManager.GetFormattedMessage(
+                            ChatManager.RawMessages[i],
+                            ChatManager.Timestamps[i],
+                            ChatManager.NotificationFlags[i]));
+                    }
+                    else if ((!ChatManager.PrivateFlags[i] || ChatManager.SystemFlags[i]) &&
                              !ChatManager.SuggestionFlags[i] && !ChatManager.NotificationFlags[i])
                     {
-                        regularMessages.Add(ChatManager.GetFormattedMessage(
+                        linesToShow.Add(ChatManager.GetFormattedMessage(
                             ChatManager.RawMessages[i],
                             ChatManager.Timestamps[i],
                             ChatManager.SuggestionFlags[i]));
                     }
                 }
             }
-            List<string> linesToShow = new List<string>();
-            if (_inPMMode && _currentPMTarget != null)
-            {
-                linesToShow.Add(ChatManager.GetFormattedMessage(
-                    $"{ChatManager.GetColorString("Private chat with ", ChatTextColor.System)}{ChatManager.GetPlayerIdentifier(_currentPMTarget)}", 
-                    DateTime.Now, 
-                    true));
-            }
-            linesToShow.AddRange(regularMessages);
-            linesToShow.AddRange(notifications);
             linesToShow.AddRange(suggestions);
             UpdateVisibleMessages(linesToShow);
         }
@@ -792,42 +808,32 @@ namespace UI
             if (e.type == EventType.KeyDown)
             {
                 bool canHandlePMKeys = IsInputActive() || _isInteractingWithChatUI;
-                if (e.keyCode == KeyCode.Tab)
+                if (e.keyCode == KeyCode.Tab && canHandlePMKeys)
                 {
-                    if (IsInputActive())
+                    bool anyPMNotification = _pmPartners.Exists(p => ChatManager.HasActivePMNotification(p.ActorNumber));
+                    if (IsInputActive() && ChatManager.HasActiveSuggestions() && !anyPMNotification)
                     {
                         e.Use();
-                        if (_inPMMode && _pmPartners.Count > 0)
-                        {
-                            CycleToPMPartner();
-                        }
-                        else
-                        {
-                            ChatManager.HandleTabComplete();
-                        }
+                        ChatManager.HandleTabComplete();
                     }
-                    else if (_inPMMode && _pmPartners.Count > 0)
+                    else if (_pmPartners.Count > 0)
                     {
                         e.Use();
                         CycleToPMPartner();
+                    }
+                    else
+                    {
+                        if (IsInputActive())
+                        {
+                            e.Use();
+                            ChatManager.HandleTabComplete();
+                        }
                     }
                 }
                 else if (e.keyCode == KeyCode.Escape && canHandlePMKeys)
                 {
                     e.Use();
-                    if (_inPMMode || _pmPartners.Count > 0)
-                    {
-                        if (_inPMMode)
-                        {
-                            ExitPMMode();
-                        }
-                        else if (_pmPartners.Count > 0)
-                        {
-                            _currentPMIndex = _pmPartners.Count - 1;
-                            EnterPMMode(_pmPartners[_currentPMIndex]);
-                        }
-                    }
-                    else if (IsInputActive())
+                    if (IsInputActive())
                     {
                         ChatManager.ClearLastSuggestions();
                     }
@@ -1182,34 +1188,120 @@ namespace UI
         private void CycleToPMPartner()
         {
             if (_pmPartners.Count == 0) return;
-            int currentIndex = -1;
-            if (_currentPMTarget != null)
+            List<Player> recencyOrdered = GetPmPartnersByRecency();
+            int partnerCount = recencyOrdered.Count;
+            int currentIndexInRecency;
+            if (_currentPMTarget == null)
             {
-                currentIndex = _pmPartners.FindIndex(p => p.ActorNumber == _currentPMTarget.ActorNumber);
+                currentIndexInRecency = partnerCount;
             }
-            if (currentIndex == -1)
+            else
             {
-                currentIndex = -1;
+                currentIndexInRecency = recencyOrdered.FindIndex(p => p.ActorNumber == _currentPMTarget.ActorNumber);
+                if (currentIndexInRecency == -1)
+                {
+                    currentIndexInRecency = _pmPartners.FindIndex(p => p.ActorNumber == _currentPMTarget.ActorNumber);
+                    if (currentIndexInRecency == -1) currentIndexInRecency = partnerCount;
+                    else
+                    {
+                        var fallback = recencyOrdered.FindIndex(p2 => p2.ActorNumber == _pmPartners[currentIndexInRecency].ActorNumber);
+                        if (fallback != -1) currentIndexInRecency = fallback;
+                    }
+                }
             }
-            int nextIndex = (currentIndex + 1) % _pmPartners.Count;
-            Player nextPartner = _pmPartners[nextIndex];
-            SaveCurrentConversation();
-            _currentPMTarget = nextPartner;
-            _currentPMIndex = nextIndex;
-            ChatManager.ClearPMNotification(nextPartner.ActorNumber);
-            var (text, caretPos) = ChatManager.GetConversation($"PM_{nextPartner.ActorNumber}");
-            SetTextAndCaretPosition(text, caretPos);
-            Sync();
+            int notifiedIndex = -1;
+            for (int i = 0; i < partnerCount; i++)
+            {
+                if (ChatManager.HasActivePMNotification(recencyOrdered[i].ActorNumber))
+                {
+                    notifiedIndex = i;
+                    break;
+                }
+            }
+            int nextIndex;
+            if (notifiedIndex != -1 && notifiedIndex != currentIndexInRecency)
+            {
+                nextIndex = notifiedIndex;
+            }
+            else
+            {
+                nextIndex = (currentIndexInRecency + 1) % (partnerCount + 1);
+            }
+            if (nextIndex == partnerCount)
+            {
+                SaveCurrentConversation();
+                ExitPMMode();
+                return;
+            }
+            Player nextPartner = recencyOrdered[nextIndex];
+            EnterPMMode(nextPartner);
+        }
+
+        private List<Player> GetPmPartnersByRecency()
+        {
+            var result = new List<Player>();
+            if (_pmPartners == null || _pmPartners.Count == 0) return result;
+            var partnerById = new Dictionary<int, Player>();
+            foreach (var p in _pmPartners)
+            {
+                if (p != null && !partnerById.ContainsKey(p.ActorNumber))
+                    partnerById[p.ActorNumber] = p;
+            }
+            var seen = new HashSet<int>();
+            for (int i = ChatManager.PMPartnerIDs.Count - 1; i >= 0; i--)
+            {
+                if (i < 0) continue;
+                if (i >= ChatManager.PrivateFlags.Count) continue;
+                if (!ChatManager.PrivateFlags[i]) continue;
+                int id = ChatManager.PMPartnerIDs[i];
+                if (id <= 0) continue;
+                if (seen.Contains(id)) continue;
+                seen.Add(id);
+                if (partnerById.TryGetValue(id, out var player))
+                {
+                    result.Add(player);
+                }
+            }
+            foreach (var p in _pmPartners)
+            {
+                if (p == null) continue;
+                if (!result.Any(r => r.ActorNumber == p.ActorNumber))
+                    result.Add(p);
+            }
+
+            return result;
         }
 
         public void AddPMPartner(Player player)
         {
             if (player == null || player.ActorNumber == PhotonNetwork.LocalPlayer.ActorNumber)
                 return;
-            if (!_pmPartners.Exists(p => p.ActorNumber == player.ActorNumber))
+            int existing = _pmPartners.FindIndex(p => p.ActorNumber == player.ActorNumber);
+            if (existing != -1)
             {
-                _pmPartners.Add(player);
+                var existingPlayer = _pmPartners[existing];
+                _pmPartners.RemoveAt(existing);
+                _pmPartners.Add(existingPlayer);
+                return;
             }
+            const int MAX_PM_CONVERSATIONS = 10;
+            if (_pmPartners.Count >= MAX_PM_CONVERSATIONS)
+            {
+                var oldest = _pmPartners[0];
+                if (oldest != null)
+                {
+                    ChatManager.ClearConversation($"PM_{oldest.ActorNumber}");
+                    ChatManager.ClearPMNotification(oldest.ActorNumber);
+                    ChatManager.ResetNotifiedForPM(oldest.ActorNumber);
+                }
+                _pmPartners.RemoveAt(0);
+                if (_currentPMTarget != null && _currentPMTarget.ActorNumber == (oldest?.ActorNumber ?? -1))
+                {
+                    _currentPMTarget = null;
+                    _inPMMode = false;
+                }
+            }
+            _pmPartners.Add(player);
         }
 
         public Player GetCurrentPMTarget()

--- a/Assets/Scripts/Utility/Extensions/MiscExtensions.cs
+++ b/Assets/Scripts/Utility/Extensions/MiscExtensions.cs
@@ -25,6 +25,50 @@ static class MiscExtensions
     static readonly Regex ColorEndRegex = new Regex(ColorEndPattern);
     static readonly Regex TagRegex = new Regex(TagPattern);
     static readonly Regex IllegalStyleRegex = new Regex(SizePattern + "|" + MaterialPattern + "|" + QuadPattern);
+    private static readonly Regex NamedColorTagRegex = new Regex(@"<color=(\w+)>", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    public static readonly Dictionary<string, string> NamedColorHex = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+    {
+        { "aqua",  "#00ffffff" },
+        { "cyan",  "#00ffffff" },
+        { "brown", "#a52a2aff" },
+        { "darkblue", "#0000a0ff" },
+        { "fuchsia", "#ff00ffff" },
+        { "magenta", "#ff00ffff" },
+        { "grey",  "#808080ff" },
+        { "lightblue", "#add8e6ff" },
+        { "lime",  "#00ff00ff" },
+        { "maroon", "#800000ff" },
+        { "navy",  "#000080ff" },
+        { "olive", "#808000ff" },
+        { "silver","#c0c0c0ff" },
+        { "teal",  "#008080ff" },
+    };
+
+    public static string ResolveNamedColorHex(string name)
+    {
+        if (string.IsNullOrEmpty(name)) return null;
+        if (NamedColorHex.TryGetValue(name, out string hex))
+        {
+            return hex.StartsWith("#") ? hex.Substring(1) : hex;
+        }
+        return null;
+    }
+
+    public static string ReplaceNamedColorTags(string input)
+    {
+        if (string.IsNullOrEmpty(input)) return input;
+        return NamedColorTagRegex.Replace(input, match =>
+        {
+            string name = match.Groups[1].Value;
+            string hex = ResolveNamedColorHex(name);
+            if (!string.IsNullOrEmpty(hex))
+            {
+                return "<color=#" + hex + ">";
+            }
+            return match.Value;
+        });
+    }
 
     public static bool GetActive(this GameObject target)
     {


### PR DESCRIPTION
### Private Messages (PM):

PM's and public chat all cycle with 'tab' instead of 2 binds to enter PM state(esc) and cycle PM's(tab).

PM's enter and cycle in order of recency, with public chat last.

Maximum of 10 PM conversations at a time where the oldest will get removed.

Each player gets only 1 notification per conversation. This is to avoid redundant/spam notifications as players should remember to toggle after starting a new conversation.

PM notifications flow with other public chats instead of remaining at the bottom.

</br>

### Rich Text Tags:

More robust way to only strip rich tags when copying from chat, allowing pastes from external copied rich tags

Disabled rich tags in input field.

Mapped missing named colors that was previously supported by unity that TextMeshPro(TMP) removed (<color="colorName">)
ex. 
Unity allows: aqua black blue brown cyan darkblue fuchsia green grey lightblue lime magenta maroon navy olive orange purple red silver teal white yellow
TMP allows only: black, blue, green, orange, purple, red, white, and yellow.


